### PR TITLE
Implement safe vertical hashing appropriate for wide datasets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(${BINARY}_lib STATIC ${lib_sources})
 
 option(SAFE_VERTICAL_HASHING
         "Enable safe vertical hashing. This feature allows to process\
-         wide (>16 columns) datasets, possibly lowering the performance."
+         wide (>32 columns) datasets, possibly lowering the performance."
         OFF)
 if (SAFE_VERTICAL_HASHING)
     target_compile_definitions(${BINARY}_lib PUBLIC SAFE_VERTICAL_HASHING)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,14 @@ file(GLOB_RECURSE lib_sources "*/*.h*" "*/*.cpp*" "*/*.cc*")
 
 add_library(${BINARY}_lib STATIC ${lib_sources})
 
+option(SAFE_VERTICAL_HASHING
+        "Enable safe vertical hashing. This feature allows to process\
+         wide (>16 columns) datasets, possibly lowering the performance."
+        OFF)
+if (SAFE_VERTICAL_HASHING)
+    target_compile_definitions(${BINARY}_lib PUBLIC SAFE_VERTICAL_HASHING)
+endif(SAFE_VERTICAL_HASHING)
+
 set(run_sources "main.cpp")
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/src/custom/CustomHashes.h
+++ b/src/custom/CustomHashes.h
@@ -3,11 +3,48 @@
 #include "RelationalSchema.h"
 #include "Vertical.h"
 
+class CustomHashing {
+private:
+    enum class BitsetHashingMethod {
+        kTryConvertToUlong,
+        kTrimAndConvertToUlong
+    };
+
+    static constexpr BitsetHashingMethod defaultHashingMethod =
+#ifdef SAFE_VERTICAL_HASHING
+        BitsetHashingMethod::kTrimAndConvertToUlong;
+#else
+        BitsetHashingMethod::kTryConvertToUlong;
+#endif
+
+    template <auto bitsetHashingMethod = defaultHashingMethod>
+    static size_t bitset_hash(boost::dynamic_bitset<> const& bitset);
+
+    friend std::hash<Vertical>;
+    friend std::hash<Column>;
+};
+
+template <>
+inline size_t CustomHashing::bitset_hash<CustomHashing::BitsetHashingMethod::kTryConvertToUlong>
+        (boost::dynamic_bitset<> const& bitset) {
+
+    return bitset.to_ulong();
+}
+
+template <>
+inline size_t CustomHashing::bitset_hash<CustomHashing::BitsetHashingMethod::kTrimAndConvertToUlong>
+        (boost::dynamic_bitset<> const& bitset) {
+
+    boost::dynamic_bitset<> copyBitset = bitset;
+    copyBitset.resize(std::numeric_limits<unsigned long>::digits);
+    return copyBitset.to_ulong();
+}
+
 namespace std {
     template<>
     struct hash<Vertical> {
         size_t operator()(Vertical const& k) const {
-            return k.getColumnIndicesRef().to_ulong();
+            return CustomHashing::bitset_hash(k.getColumnIndicesRef());
         }
     };
 
@@ -16,37 +53,35 @@ namespace std {
         size_t operator()(Column const& k) const {
             boost::dynamic_bitset<> columnIndex(k.getSchema()->getNumColumns());
             columnIndex.set(k.getIndex());
-            return columnIndex.to_ulong();
+            return CustomHashing::bitset_hash(columnIndex);
         }
     };
 
     template<>
     struct hash<std::shared_ptr<Vertical>> {
         size_t operator()(std::shared_ptr<Vertical> const& k) const {
-            return k->getColumnIndices().to_ulong();
+            return std::hash<Vertical>()(*k);
         }
     };
 
     template<>
     struct hash<std::shared_ptr<Column>> {
         size_t operator()(std::shared_ptr<Column> const& k) const {
-            boost::dynamic_bitset<> columnIndex(k->getSchema()->getNumColumns());
-            columnIndex.set(k->getIndex());
-            return columnIndex.to_ulong();
+            return std::hash<Column>()(*k);
         }
     };
 
     template<class T>
     struct hash<std::pair<Vertical, T>> {
         size_t operator()(std::pair<Vertical, T> const& k) const {
-            return k.first.getColumnIndices().to_ulong();
+            return std::hash<Vertical>()(k.first);
         }
     };
 
     template<class T>
     struct hash<std::pair<std::shared_ptr<Vertical>, T>> {
         size_t operator()(std::pair<std::shared_ptr<Vertical>, T> const& k) const {
-            return k.first->getColumnIndices().to_ulong();
+            return std::hash<Vertical>()(*k.first);
         }
     };
 }

--- a/src/custom/CustomHashes.h
+++ b/src/custom/CustomHashes.h
@@ -10,29 +10,29 @@ private:
         kTrimAndConvertToUlong
     };
 
-    static constexpr BitsetHashingMethod defaultHashingMethod =
+    static constexpr BitsetHashingMethod kDefaultHashingMethod =
 #ifdef SAFE_VERTICAL_HASHING
         BitsetHashingMethod::kTrimAndConvertToUlong;
 #else
         BitsetHashingMethod::kTryConvertToUlong;
 #endif
 
-    template <auto bitsetHashingMethod = defaultHashingMethod>
-    static size_t bitset_hash(boost::dynamic_bitset<> const& bitset);
+    template <auto bitsetHashingMethod = kDefaultHashingMethod>
+    static size_t BitsetHash(boost::dynamic_bitset<> const& bitset);
 
     friend std::hash<Vertical>;
     friend std::hash<Column>;
 };
 
 template <>
-inline size_t CustomHashing::bitset_hash<CustomHashing::BitsetHashingMethod::kTryConvertToUlong>
+inline size_t CustomHashing::BitsetHash<CustomHashing::BitsetHashingMethod::kTryConvertToUlong>
         (boost::dynamic_bitset<> const& bitset) {
 
     return bitset.to_ulong();
 }
 
 template <>
-inline size_t CustomHashing::bitset_hash<CustomHashing::BitsetHashingMethod::kTrimAndConvertToUlong>
+inline size_t CustomHashing::BitsetHash<CustomHashing::BitsetHashingMethod::kTrimAndConvertToUlong>
         (boost::dynamic_bitset<> const& bitset) {
 
     boost::dynamic_bitset<> copyBitset = bitset;
@@ -44,16 +44,14 @@ namespace std {
     template<>
     struct hash<Vertical> {
         size_t operator()(Vertical const& k) const {
-            return CustomHashing::bitset_hash(k.getColumnIndicesRef());
+            return CustomHashing::BitsetHash(k.getColumnIndicesRef());
         }
     };
 
     template<>
     struct hash<Column> {
         size_t operator()(Column const& k) const {
-            boost::dynamic_bitset<> columnIndex(k.getSchema()->getNumColumns());
-            columnIndex.set(k.getIndex());
-            return CustomHashing::bitset_hash(columnIndex);
+            return k.getIndex();
         }
     };
 


### PR DESCRIPTION
The problem with the previous hashing method is that just using the to_ulong method on a bitset of size > 16 yields an overflow exception. This makes Desbordante inapplicable to wide datasets, as every algorithm uses hashing data structures.

The solution is to implement an alternative hashing method, which takes into account only the first 16 bits of a bitset. Such an approach, however, possibly could slow down the hashing structures, therefore for now it is not the default option. One can activate it with an addition of `-DSAFE_VERTICAL_HASHING=ON` option to a CMake call. It is implemented as a compile time option, as a runtime implementation would probably have a heavier impact on the hashing performance.