### PR TITLE
Extend algorithm hierarchical tree with PliBasedFDAlgorithm

### DIFF
--- a/src/algorithms/DFD/DFD.cpp
+++ b/src/algorithms/DFD/DFD.cpp
@@ -64,12 +64,12 @@ unsigned long long DFD::executeInternal() {
 
     //std::cout << "====JSON-FD========\r\n" << getJsonFDs() << std::endl;
     std::cout << "> FD COUNT: " << fdCollection_.size() << std::endl;
-    std::cout << "> HASH: " << FDAlgorithm::fletcher16() << std::endl;
+    std::cout << "> HASH: " << PliBasedFDAlgorithm::fletcher16() << std::endl;
 
     return aprioriMillis;
 }
 
 DFD::DFD(const std::filesystem::path &path, char separator, bool hasHeader, unsigned int parallelism)
-        : FDAlgorithm(path, separator, hasHeader),
+        : PliBasedFDAlgorithm(path, separator, hasHeader),
           numberOfThreads(parallelism <= 0 ? std::thread::hardware_concurrency() : parallelism) {}
 

--- a/src/algorithms/DFD/DFD.h
+++ b/src/algorithms/DFD/DFD.h
@@ -3,11 +3,11 @@
 #include <random>
 #include <stack>
 
-#include "FDAlgorithm.h"
+#include "PliBasedFDAlgorithm.h"
 #include "Vertical.h"
 #include "DFD/PartitionStorage/PartitionStorage.h"
 
-class DFD : public FDAlgorithm {
+class DFD : public PliBasedFDAlgorithm {
 private:
     std::unique_ptr<PartitionStorage> partitionStorage;
     std::vector<Vertical> uniqueColumns;

--- a/src/algorithms/DFD/LatticeTraversal/LatticeTraversal.h
+++ b/src/algorithms/DFD/LatticeTraversal/LatticeTraversal.h
@@ -2,7 +2,6 @@
 
 #include <stack>
 
-#include "FDAlgorithm.h"
 #include "Vertical.h"
 #include "DFD/ColumnOrder/ColumnOrder.h"
 #include "DFD/LatticeObservations/LatticeObservations.h"

--- a/src/algorithms/FDAlgorithm.cpp
+++ b/src/algorithms/FDAlgorithm.cpp
@@ -1,11 +1,7 @@
 #include "FDAlgorithm.h"
 
 unsigned long long FDAlgorithm::execute() {
-    relation_ = ColumnLayoutRelationData::createFrom(inputGenerator_, is_null_equal_null_);
-
-    if (relation_->getColumnData().empty()) {
-        throw std::runtime_error("Got an empty .csv file: FD mining is meaningless.");
-    }
+    initialize();
 
     return executeInternal();
 }

--- a/src/algorithms/FDAlgorithm.h
+++ b/src/algorithms/FDAlgorithm.h
@@ -6,7 +6,6 @@
 
 #include "CSVParser.h"
 #include "FD.h"
-#include "ColumnLayoutRelationData.h"
 
 namespace util {
     class AgreeSetFactory;
@@ -25,11 +24,12 @@ private:
     double cur_phase_progress_ = 0;
     uint8_t cur_phase_id = 0;
 
+protected:
+
     /* создаётся в конструкторе, дальше предполагается передать его один раз в
      * ColumnLayoutRelationData в execute(), и больше не трогать
      * */
     CSVParser inputGenerator_;
-protected:
     /* содержит множество найденных функциональных зависимостей. Это поле будет использоваться при тестировании,
      * поэтому важно положить сюда все намайненные ФЗ
      * */
@@ -40,13 +40,13 @@ protected:
      */
     std::vector<std::string_view> const phase_names_;
 
-    std::unique_ptr<ColumnLayoutRelationData> relation_;
     bool const is_null_equal_null_;
 
     void addProgress(double const val) noexcept;
     void setProgress(double const val) noexcept;
     void toNextProgressPhase() noexcept;
 
+    virtual void initialize() = 0;
     // Main logic of the algorithm
     virtual unsigned long long executeInternal() = 0;
 public:
@@ -91,12 +91,6 @@ public:
     unsigned int fletcher16();
 
     unsigned long long execute();
-
-    ColumnLayoutRelationData const& getRelation() const noexcept {
-        // getRealtion should be called after input file is parsed i.e. after algorithm execution
-        assert(relation_ != nullptr);
-        return *relation_;
-    }
 
     virtual ~FDAlgorithm() = default;
 };

--- a/src/algorithms/FastFDs.cpp
+++ b/src/algorithms/FastFDs.cpp
@@ -18,7 +18,7 @@ using std::vector, std::set;
 FastFDs::FastFDs(std::filesystem::path const& path,
                  char separator, bool hasHeader,
                  unsigned int max_lhs, ushort parallelism) :
-    FDAlgorithm(path, separator, hasHeader, true,
+    PliBasedFDAlgorithm(path, separator, hasHeader, true,
                 { "Agree sets generation", "Finding minimal covers" }), max_lhs_(max_lhs) {
     if (parallelism == 0) {
         threads_num_ = std::thread::hardware_concurrency();

--- a/src/algorithms/FastFDs.h
+++ b/src/algorithms/FastFDs.h
@@ -4,11 +4,11 @@
 
 #include <boost/thread/mutex.hpp>
 
-#include "Vertical.h"
-#include "FDAlgorithm.h"
 #include "ColumnLayoutRelationData.h"
+#include "PliBasedFDAlgorithm.h"
+#include "Vertical.h"
 
-class FastFDs : public FDAlgorithm {
+class FastFDs : public PliBasedFDAlgorithm {
 public:
     explicit FastFDs(std::filesystem::path const& path,
                      char separator = ',', bool hasHeader = true,

--- a/src/algorithms/Fd_mine.h
+++ b/src/algorithms/Fd_mine.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include <boost/unordered_map.hpp>
 #include <filesystem>
@@ -6,11 +7,11 @@
 #include "CSVParser.h"
 #include "ColumnCombination.h"
 #include "ColumnLayoutRelationData.h"
-#include "FDAlgorithm.h"
+#include "PliBasedFDAlgorithm.h"
 #include "PositionListIndex.h"
 #include "Vertical.h"
 
-class Fd_mine : public FDAlgorithm {
+class Fd_mine : public PliBasedFDAlgorithm {
    private:
     const RelationalSchema* schema;
 
@@ -33,6 +34,6 @@ class Fd_mine : public FDAlgorithm {
 
     unsigned long long executeInternal() override;
    public:
-    Fd_mine(std::filesystem::path const& path, char separator = ',', bool hasHeader = true) : FDAlgorithm(path, separator, hasHeader){};
+    Fd_mine(std::filesystem::path const& path, char separator = ',', bool hasHeader = true) : PliBasedFDAlgorithm(path, separator, hasHeader){};
     ~Fd_mine() override {}
 };

--- a/src/algorithms/Fd_mine.h
+++ b/src/algorithms/Fd_mine.h
@@ -33,7 +33,8 @@ class Fd_mine : public PliBasedFDAlgorithm {
     void display();
 
     unsigned long long executeInternal() override;
-   public:
-    Fd_mine(std::filesystem::path const& path, char separator = ',', bool hasHeader = true) : PliBasedFDAlgorithm(path, separator, hasHeader){};
+public:
+    Fd_mine(std::filesystem::path const& path, char separator = ',', bool hasHeader = true)
+            : PliBasedFDAlgorithm(path, separator, hasHeader) {}
     ~Fd_mine() override {}
 };

--- a/src/algorithms/PliBasedFDAlgorithm.cpp
+++ b/src/algorithms/PliBasedFDAlgorithm.cpp
@@ -1,0 +1,9 @@
+#include "PliBasedFDAlgorithm.h"
+
+void PliBasedFDAlgorithm::initialize() {
+    relation_ = ColumnLayoutRelationData::createFrom(inputGenerator_, is_null_equal_null_);
+
+    if (relation_->getColumnData().empty()) {
+        throw std::runtime_error("Got an empty .csv file: FD mining is meaningless.");
+    }
+}

--- a/src/algorithms/PliBasedFDAlgorithm.h
+++ b/src/algorithms/PliBasedFDAlgorithm.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "ColumnLayoutRelationData.h"
+#include "FDAlgorithm.h"
+
+class PliBasedFDAlgorithm : public FDAlgorithm {
+private:
+    void initialize() override;
+
+protected:
+    std::unique_ptr<ColumnLayoutRelationData> relation_;
+
+    ColumnLayoutRelationData const& getRelation() const noexcept {
+        // getRelation should be called after input file is parsed i.e. after algorithm execution
+        assert(relation_ != nullptr);
+        return *relation_;
+    }
+
+public:
+    explicit PliBasedFDAlgorithm(std::filesystem::path const& path,
+                                 char separator = ',', bool hasHeader = true,
+                                 bool const is_null_equal_null = true,
+                                 std::vector<std::string_view> phase_names = { "FD mining" }) :
+                                 FDAlgorithm(path, separator, hasHeader, is_null_equal_null, std::move(phase_names)) {}
+};

--- a/src/algorithms/Pyro.cpp
+++ b/src/algorithms/Pyro.cpp
@@ -113,14 +113,14 @@ unsigned long long Pyro::executeInternal() {
     std::cout << "====RESULTS-UCC====\r\n" << uccsToString();
     std::cout << "====JSON-FD========\r\n" << FDAlgorithm::getJsonFDs() << std::endl;*/
 
-    std::cout << "HASH: " << FDAlgorithm::fletcher16() << std::endl;
+    std::cout << "HASH: " << PliBasedFDAlgorithm::fletcher16() << std::endl;
     return elapsed_milliseconds.count();
 }
 
 
 Pyro::Pyro(std::filesystem::path const &path, char separator, bool hasHeader, int seed, double maxError,
            unsigned int maxLHS, int parallelism) :
-        FDAlgorithm(path, separator, hasHeader),
+        PliBasedFDAlgorithm(path, separator, hasHeader),
         cachingMethod_(CachingMethod::COIN),
         evictionMethod_(CacheEvictionMethod::DEFAULT) {
     uccConsumer_ = [this](auto const& key) { this->discoveredUCCs_.push_back(key); };

--- a/src/algorithms/Pyro.h
+++ b/src/algorithms/Pyro.h
@@ -1,12 +1,13 @@
 #pragma once
 #include <list>
 #include <mutex>
-#include "DependencyConsumer.h"
-#include "FDAlgorithm.h"
-#include "SearchSpace.h"
-#include "CSVParser.h"
 
-class Pyro : public DependencyConsumer, public FDAlgorithm {
+#include "CSVParser.h"
+#include "DependencyConsumer.h"
+#include "PliBasedFDAlgorithm.h"
+#include "SearchSpace.h"
+
+class Pyro : public DependencyConsumer, public PliBasedFDAlgorithm {
 private:
     std::list<std::unique_ptr<SearchSpace>> searchSpaces_;
 

--- a/src/algorithms/TaneX.cpp
+++ b/src/algorithms/TaneX.cpp
@@ -40,7 +40,7 @@ void Tane::registerFD(Vertical const& lhs, Column const* rhs, double error,
         std::cout << schema->getColumn(i)->getName() << " ";
     }
     std::cout << "-> " << rhs->getName() << " - error equals " << error << std::endl;*/
-    FDAlgorithm::registerFD(lhs, *rhs);
+    PliBasedFDAlgorithm::registerFD(lhs, *rhs);
     countOfFD++;
 }
 

--- a/src/algorithms/TaneX.h
+++ b/src/algorithms/TaneX.h
@@ -3,11 +3,11 @@
 #include <string>
 
 #include "CSVParser.h"
-#include "FDAlgorithm.h"
+#include "PliBasedFDAlgorithm.h"
 #include "PositionListIndex.h"
 #include "RelationData.h"
 
-class Tane : public FDAlgorithm {
+class Tane : public PliBasedFDAlgorithm {
 private:
     unsigned long long executeInternal() override;
 public:
@@ -26,7 +26,7 @@ public:
     explicit Tane(
             std::filesystem::path const& path, char separator = ',', bool hasHeader = true,
             double maxError = 0, unsigned int maxArity = -1)
-            : FDAlgorithm(path, separator, hasHeader), maxFdError(maxError), maxUccError(maxError), maxArity(maxArity) {}
+            : PliBasedFDAlgorithm(path, separator, hasHeader), maxFdError(maxError), maxUccError(maxError), maxArity(maxArity) {}
 
     static double calculateZeroAryFdError(ColumnData const* rhs,
                                           ColumnLayoutRelationData const* relationData);


### PR DESCRIPTION
Relation initialization may differ from algorithm to algorithm. While Tane, Pyro, FastFDs, FDMine and DFD can be implemented using only PLIs, certain other algorithms, namely row-based Fdep, cannot. Therefore, construction of a data structure representing the whole table must be present in a FDAlgorithm only as a general step, but implemented in a special subclass.

- extend algorithm hierarchical tree: FDAlgorithm [-> PliBasedFDAlgorithm] -> Tane/FastFDs/FDMine/Pyro/DFD
- this ensures FDAlgorithm compatibility with FDep