### PR TITLE
Fix Pyro datarace errors

### DIFF
--- a/src/algorithms/Pyro.cpp
+++ b/src/algorithms/Pyro.cpp
@@ -123,13 +123,19 @@ Pyro::Pyro(std::filesystem::path const &path, char separator, bool hasHeader, in
         PliBasedFDAlgorithm(path, separator, hasHeader),
         cachingMethod_(CachingMethod::COIN),
         evictionMethod_(CacheEvictionMethod::DEFAULT) {
-    uccConsumer_ = [this](auto const& key) { this->discoveredUCCs_.push_back(key); };
+    uccConsumer_ = [this](auto const& key) {
+        this->discoverUCC(key);
+    };
     fdConsumer_ = [this](auto const& fd) {
-        this->discoveredFDs_.push_back(fd); this->fdCollection_.emplace_back(fd.lhs_, fd.rhs_); };
+        this->discoverFD(fd);
+        this->registerFD(fd.lhs_, fd.rhs_);
+    };
     configuration_.seed = seed;
     configuration_.maxUccError = maxError;
     configuration_.maxUccError = maxError;
     configuration_.maxLHS = maxLHS;
-    configuration_.parallelism = parallelism <= 0 ? std::thread::hardware_concurrency() : parallelism;
+    configuration_.parallelism = parallelism <= 0 ?
+                                 std::thread::hardware_concurrency() :
+                                 parallelism;
 }
 

--- a/src/core/DependencyConsumer.cpp
+++ b/src/core/DependencyConsumer.cpp
@@ -1,13 +1,15 @@
 
 #include "DependencyConsumer.h"
 
-PartialFD DependencyConsumer::registerFd(Vertical const& lhs, Column const& rhs, double error, double score) const {
+PartialFD DependencyConsumer::registerFd(Vertical const& lhs, Column const& rhs,
+                                         double error, double score) const {
     PartialFD partialFd(lhs, rhs, error, score);
     fdConsumer_(partialFd);
     return partialFd;
 }
 
-PartialKey DependencyConsumer::registerUcc(Vertical const& keyVertical, double error, double score) const {
+PartialKey DependencyConsumer::registerUcc(Vertical const& keyVertical,
+                                           double error, double score) const {
     PartialKey partialKey(keyVertical, error, score);
     uccConsumer_(partialKey);
     return partialKey;

--- a/src/core/DependencyConsumer.h
+++ b/src/core/DependencyConsumer.h
@@ -1,19 +1,38 @@
 #pragma once
 #include <functional>
 #include <list>
+#include <mutex>
+
 #include "PartialFD.h"
 #include "PartialKey.h"
 
 class DependencyConsumer {
-protected:
-    std::function<void (PartialFD const&)> fdConsumer_;
-    std::function<void (PartialKey const&)> uccConsumer_;
-public:
+private:
+    std::mutex mutable discover_fd_mutex_;
+    std::mutex mutable discover_ucc_mutex_;
+
     std::list<PartialFD> discoveredFDs_;
     std::list<PartialKey> discoveredUCCs_;
 
-    PartialFD registerFd(Vertical const& lhs, Column const& rhs, double error, double score) const;
-    PartialKey registerUcc(Vertical const& keyVertical, double error, double score) const;
+protected:
+    std::function<void (PartialFD const&)> fdConsumer_;
+    std::function<void (PartialKey const&)> uccConsumer_;
+
+    void discoverFD(PartialFD const& fd) {
+        std::scoped_lock lock(discover_fd_mutex_);
+        discoveredFDs_.push_back(fd);
+    }
+
+    void discoverUCC(PartialKey const& key) {
+        std::scoped_lock lock(discover_ucc_mutex_);
+        discoveredUCCs_.push_back(key);
+    }
+
+public:
+    PartialFD registerFd(Vertical const& lhs, Column const& rhs, double error,
+                         double score) const;
+    PartialKey registerUcc(Vertical const& keyVertical, double error,
+                           double score) const;
 
     std::string fdsToString() const;
     std::string uccsToString() const;

--- a/src/core/SearchSpace.cpp
+++ b/src/core/SearchSpace.cpp
@@ -4,7 +4,7 @@
 // TODO: extra careful with const& -> shared_ptr conversions via make_shared-smart pointer may delete the object - pass empty deleter [](*) {}
 
 void SearchSpace::discover() {
-    std::cout << "Discovering in: " << static_cast<std::string>(*strategy_) << std::endl;
+    LOG(TRACE) << "Discovering in: " << static_cast<std::string>(*strategy_);
     while (true) {  // на второй итерации дропается
         auto now = std::chrono::system_clock::now();
         std::optional<DependencyCandidate> launchPad = pollLaunchPad();


### PR DESCRIPTION
One datarace was in SearchSpace::discover() with std::cout usage from different threads. Replaced std::cout with thread-safe LOG(). We really need to replace all output via std::cout with easylogging lib, at least to avoid such problems (#23). Registering mined uccs and fds from different threads also lead to the datarace. Synchronized registration to fix it.