### PR TITLE
Implement functionality to find specific lines containing typos 

### DIFF
--- a/src/algorithms/Primitive.h
+++ b/src/algorithms/Primitive.h
@@ -38,9 +38,12 @@ public:
     Primitive& operator=(Primitive&& other) = delete;
     virtual ~Primitive() = default;
 
-    Primitive(std::vector<std::string_view> phase_names) : phase_names_(std::move(phase_names)) {}
-    explicit Primitive(std::filesystem::path const& path, char const separator,
-                       bool const has_header, std::vector<std::string_view> phase_names)
+    explicit Primitive(std::vector<std::string_view> phase_names)
+        : phase_names_(std::move(phase_names)) {}
+    Primitive(CSVParser input_generator, std::vector<std::string_view> phase_names)
+        : input_generator_(std::move(input_generator)), phase_names_(std::move(phase_names)) {}
+    Primitive(std::filesystem::path const& path, char const separator, bool const has_header,
+              std::vector<std::string_view> phase_names)
         : input_generator_(path, separator, has_header), phase_names_(std::move(phase_names)) {}
 
     virtual unsigned long long Execute() = 0;

--- a/src/algorithms/TypoMiner.cpp
+++ b/src/algorithms/TypoMiner.cpp
@@ -1,0 +1,244 @@
+#include "TypoMiner.h"
+
+namespace algos {
+
+unsigned long long TypoMiner::Execute() {
+    auto const start_time = std::chrono::system_clock::now();
+
+    precise_algo_->Execute();
+    approx_algo_->Execute();
+
+    std::list<FD>& precise_fds = precise_algo_->FdList();
+    std::list<FD>& approx_fds = approx_algo_->FdList();
+
+    precise_fds.sort(FDLess);
+    approx_fds.sort(FDLess);
+
+    std::set_difference(approx_fds.begin(), approx_fds.end(), precise_fds.begin(),
+                        precise_fds.end(), std::back_inserter(approx_fds_), FDLess);
+
+    auto const elapsed_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now() - start_time);
+
+    return elapsed_milliseconds.count();
+}
+
+auto TypoMiner::MakeTuplesByIndicesComparator(std::map<int, unsigned> const& frequency_map) {
+    return [&frequency_map](int const l, int const r) {
+        return frequency_map.at(l) < frequency_map.at(r);
+    };
+}
+
+std::vector<util::PLI::Cluster> TypoMiner::FindClustersWithTypos(FD const& typos_fd,
+                                                                 bool const sort_clusters) {
+    std::vector<util::PLI::Cluster> clusters;
+    std::shared_ptr<util::PLI const> intersection_pli;
+    std::vector<Column const*> const lhs_columns = typos_fd.GetLhs().GetColumns();
+    std::vector<int> const& probing_table =
+        relation_->GetColumnData(typos_fd.GetRhs().GetIndex()).GetProbingTable();
+
+    assert(!lhs_columns.empty());
+
+    for (Column const* col : lhs_columns) {
+        ColumnData const& col_data = relation_->GetColumnData(col->GetIndex());
+        std::shared_ptr<util::PLI const> pli = col_data.GetPliOwnership();
+
+        if (intersection_pli == nullptr) {
+            intersection_pli = pli;
+        } else {
+            intersection_pli = intersection_pli->Intersect(pli.get());
+        }
+    }
+
+    for (util::PLI::Cluster const& cluster : intersection_pli->GetIndex()) {
+        int cluster_rhs_value = -1;
+
+        /* Check if fd has wrong rhs values in this cluster */
+        for (int const tuple_index : cluster) {
+            int const probing_table_value = probing_table[tuple_index];
+
+            if (cluster_rhs_value == -1) {
+                cluster_rhs_value = probing_table_value;
+            } else if (cluster_rhs_value != probing_table_value) {
+                cluster_rhs_value = -1;
+                break;
+            }
+        }
+
+        if (cluster_rhs_value == -1 || (cluster_rhs_value == 0 && cluster.size() != 1)) {
+            /* Actually intersection_pli is owned only by this method most of the time
+             * (when lhs_columns.size() != 1), so we can here move cluster when
+             * lhs_columns.size() != 1. But that leads to more cumbersome and complex code.
+             * So I decided to leave it as it is until we know for sure that this place causes
+             * performance problems.
+             */
+            clusters.push_back(cluster);
+
+            if (sort_clusters) {
+                std::map<int, unsigned> const frequency_map =
+                    CreateFrequencyMap(typos_fd.GetRhs(), clusters.back());
+                std::stable_sort(clusters.back().begin(), clusters.back().end(),
+                                 MakeTuplesByIndicesComparator(frequency_map));
+            }
+        }
+    }
+
+    return clusters;
+}
+
+std::vector<TypoMiner::SquashedElement> TypoMiner::SquashCluster(
+    FD const& squash_on, util::PLI::Cluster const& cluster) {
+    std::vector<SquashedElement> squashed;
+    std::vector<int> const& probing_table =
+        relation_->GetColumnData(squash_on.GetRhs().GetIndex()).GetProbingTable();
+
+    if (cluster.empty()) {
+        return squashed;
+    }
+
+    auto prev = cluster.begin();
+    squashed.push_back({.tuple_index = *prev, .amount = 1});
+
+    for (auto it = std::next(cluster.cbegin()); it != cluster.cend(); ++it) {
+        if (probing_table[*it] == probing_table[*prev]) {
+            squashed.back().amount++;
+        } else {
+            squashed.push_back({.tuple_index = *it, .amount = 1});
+        }
+        prev = it;
+    }
+
+    return squashed;
+}
+
+void TypoMiner::SortCluster(FD const& sort_on, util::PLI::Cluster& cluster) const {
+    std::map<int, unsigned> const frequency_map = CreateFrequencyMap(sort_on.GetRhs(), cluster);
+
+    std::stable_sort(cluster.begin(), cluster.end(), MakeTuplesByIndicesComparator(frequency_map));
+}
+
+std::vector<util::PLI::Cluster::value_type> TypoMiner::FindLinesWithTypos(
+    FD const& typos_fd, util::PLI::Cluster const& cluster, double new_radius, double new_ratio) {
+    SetRadius(new_radius);
+    SetRatio(new_ratio);
+    return FindLinesWithTypos(typos_fd, cluster);
+}
+
+std::vector<util::PLI::Cluster::value_type> TypoMiner::FindLinesWithTypos(
+    FD const& typos_fd, util::PLI::Cluster const& cluster) const {
+    std::vector<util::PLI::Cluster::value_type> typos;
+    unsigned long num_of_close_values = 0;
+    Column const& col = typos_fd.GetRhs();
+    model::TypedColumnData const& col_data = typed_relation_->GetColumnData(col.GetIndex());
+    std::vector<int> const& probing_table =
+        relation_->GetColumnData(col.GetIndex()).GetProbingTable();
+    std::vector<std::byte const*> const& data = col_data.GetData();
+    model::Type const& type = col_data.GetType();
+
+    unsigned most_freq_index = GetMostFrequentValueIndex(col, cluster);
+    int most_freq_value = probing_table[most_freq_index];
+
+    if (most_freq_value == 0 || col_data.IsMixed() || !type.IsMetrizable()) {
+        if (ratio_ == 1) {
+            return cluster;
+        }
+        return {};
+    }
+
+    for (util::PLI::Cluster::value_type tuple_index : cluster) {
+        if (most_freq_value == probing_table[tuple_index]) {
+            continue;
+        }
+        if (radius_ == -1 || ValuesAreClose(data[most_freq_index], data[tuple_index], type)) {
+            num_of_close_values++;
+            typos.push_back(tuple_index);
+        }
+    }
+
+    if (double(num_of_close_values) / col_data.GetNumRows() > ratio_) {
+        return {};
+    }
+
+    return typos;
+}
+
+std::vector<TypoMiner::ClusterTyposPair> TypoMiner::FindClustersAndLinesWithTypos(
+    const FD& typos_fd, const bool sort_clusters) {
+    std::vector<ClusterTyposPair> result;
+    std::vector<util::PLI::Cluster> clusters = FindClustersWithTypos(typos_fd, sort_clusters);
+
+    result.reserve(clusters.size());
+
+    for (auto& cluster : clusters) {
+        TyposVec typos = FindLinesWithTypos(typos_fd, cluster);
+        if (!typos.empty()) {
+            result.emplace_back(std::move(cluster), std::move(typos));
+        }
+    }
+
+    return result;
+}
+
+std::unordered_map<int, unsigned> TypoMiner::CreateFrequencies(
+    util::PLI::Cluster const& cluster, std::vector<int> const& probing_table) const {
+    std::unordered_map<int, unsigned> frequencies;
+
+    for (int const tuple_index : cluster) {
+        int const probing_table_value = probing_table[tuple_index];
+
+        if (probing_table_value != 0) {
+            frequencies[probing_table_value]++;
+        }
+    }
+
+    return frequencies;
+}
+
+unsigned TypoMiner::GetMostFrequentValueIndex(Column const& cluster_col,
+                                              util::PLI::Cluster const& cluster) const {
+    assert(!cluster.empty());
+    std::vector<int> const& probing_table =
+        relation_->GetColumnData(cluster_col.GetIndex()).GetProbingTable();
+    std::unordered_map<int, unsigned> frequencies = CreateFrequencies(cluster, probing_table);
+
+    unsigned most_frequent_index = cluster.size();
+    unsigned most_frequent_value = 0;
+    for (int const tuple_index : cluster) {
+        int const probing_table_value = probing_table[tuple_index];
+        unsigned const value = (probing_table_value == 0) ? 1 : frequencies.at(probing_table_value);
+        if (value > most_frequent_value) {
+            most_frequent_value = value;
+            most_frequent_index = tuple_index;
+        }
+    }
+
+    return most_frequent_index;
+}
+
+std::map<int, unsigned> TypoMiner::CreateFrequencyMap(Column const& cluster_col,
+                                                      util::PLI::Cluster const& cluster) const {
+    std::map<int, unsigned> frequency_map;
+    std::vector<int> const& probing_table =
+        relation_->GetColumnData(cluster_col.GetIndex()).GetProbingTable();
+    std::unordered_map<int, unsigned> frequencies = CreateFrequencies(cluster, probing_table);
+
+    for (int const tuple_index : cluster) {
+        int const probing_table_value = probing_table[tuple_index];
+        int const value = (probing_table_value == 0) ? 1 : frequencies.at(probing_table_value);
+        frequency_map[tuple_index] = value;
+    }
+
+    return frequency_map;
+}
+
+bool TypoMiner::FDLess(FD const& l, FD const& r) {
+    if (l.GetLhs() < r.GetLhs()) {
+        return true;
+    } else if (l.GetLhs() == r.GetLhs()) {
+        return l.GetRhs() < r.GetRhs();
+    }
+
+    return false;
+}
+
+}  // namespace algos

--- a/src/algorithms/TypoMiner.h
+++ b/src/algorithms/TypoMiner.h
@@ -104,6 +104,10 @@ public:
         ratio_ = ratio;
         return ratio_;
     }
+    ColumnLayoutRelationData const& GetRelationData() const noexcept {
+        assert(relation_ != nullptr);
+        return *relation_;
+    }
     std::string GetApproxFDsAsJson() const {
         return FDAlgorithm::FDsToJson(approx_fds_);
     }

--- a/src/algorithms/TypoMiner.h
+++ b/src/algorithms/TypoMiner.h
@@ -7,8 +7,10 @@
 
 namespace algos {
 
-template<typename PreciseAlgo, typename ApproxAlgo = Pyro>
 class TypoMiner : public Primitive {
+public:
+    using Config = FDAlgorithm::Config;
+
 private:
     std::unique_ptr<FDAlgorithm> precise_algo_;
     std::unique_ptr<FDAlgorithm> approx_algo_;
@@ -22,9 +24,21 @@ private:
 
     static bool FDLess(FD const& l, FD const& r);
     static auto MakeTuplesByIndicesComparator(std::map<int, unsigned> const& frequency_map);
+    static double VerifyRadius(double radius) {
+        if (!(radius == -1 || radius >= 0)) {
+            throw std::invalid_argument("Radius should be greater or equal to zero or equal to -1");
+        }
+        return radius;
+    }
+    static double VerifyRatio(double ratio) {
+        if (!(ratio >= 0 && ratio <= 1)) {
+            throw std::invalid_argument("Ratio should be between 0 and 1");
+        }
+        return ratio;
+    }
 
-    std::unordered_map<int, unsigned> CreateFrequencies(util::PLI::Cluster const& cluster,
-                                                        std::vector<int> const& probing_table) const;
+    std::unordered_map<int, unsigned> CreateFrequencies(
+        util::PLI::Cluster const& cluster, std::vector<int> const& probing_table) const;
     std::map<int, unsigned> CreateFrequencyMap(Column const& cluster_col,
                                                util::PLI::Cluster const& cluster) const;
     unsigned GetMostFrequentValueIndex(Column const& cluster_col,
@@ -34,9 +48,22 @@ private:
         assert(type.IsMetrizable());
         return static_cast<model::IMetrizableType const&>(type).Dist(l, r) < radius_;
     }
+    explicit TypoMiner(CSVParser input_generator, std::unique_ptr<FDAlgorithm> precise_algo,
+                       std::unique_ptr<FDAlgorithm> approx_algo,
+                       std::shared_ptr<ColumnLayoutRelationData> relation,
+                       std::unique_ptr<model::ColumnLayoutTypedRelationData> typed_relation,
+                       double radius, double ratio)
+        : Primitive(std::move(input_generator),
+                    {/*"Precise fd algorithm execution", "Approximate fd algoritm execution",
+                       "Extracting fds with non-zero error"*/}),
+          precise_algo_(std::move(precise_algo)),
+          approx_algo_(std::move(approx_algo)),
+          relation_(std::move(relation)),
+          typed_relation_(std::move(typed_relation)),
+          radius_(radius),
+          ratio_(ratio) {}
 
 public:
-    using Config = FDAlgorithm::Config;
     using TyposVec = std::vector<util::PLI::Cluster::value_type>;
     using ClusterTyposPair = std::pair<util::PLI::Cluster, TyposVec>;
 
@@ -45,8 +72,6 @@ public:
         unsigned amount;  /* The number of tuples equal to the given and
                            * following immediately after the given */
     };
-
-    explicit TypoMiner(Config const& config);
 
     unsigned long long Execute() override;
 
@@ -91,17 +116,11 @@ public:
         return ratio_;
     }
     double SetRadius(double radius) {
-        if (!(radius == -1 || radius >= 0)) {
-            throw std::invalid_argument("Radius should be greater or equal to zero or equal to -1");
-        }
-        radius_ = radius;
+        radius_ = VerifyRadius(radius);
         return radius_;
     }
     double SetRatio(double ratio) {
-        if (!(ratio >= 0 && ratio <= 1)) {
-            throw std::invalid_argument("Ratio should be between 0 and 1");
-        }
-        ratio_ = ratio;
+        ratio_ = VerifyRatio(ratio);
         return ratio_;
     }
     ColumnLayoutRelationData const& GetRelationData() const noexcept {
@@ -111,13 +130,13 @@ public:
     std::string GetApproxFDsAsJson() const {
         return FDAlgorithm::FDsToJson(approx_fds_);
     }
+
+    template <typename PreciseAlgo, typename ApproxAlgo = Pyro>
+    static std::unique_ptr<TypoMiner> CreateFrom(Config const& config);
 };
 
 template <typename PreciseAlgo, typename ApproxAlgo>
-TypoMiner<PreciseAlgo, ApproxAlgo>::TypoMiner(Config const& config)
-    : Primitive(config.data, config.separator, config.has_header,
-                {/*"Precise fd algorithm execution", "Approximate fd algoritm execution",
-                 "Extracting fds with non-zero error"*/}) {
+std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
     static_assert(std::is_base_of_v<PliBasedFDAlgorithm, ApproxAlgo>,
                   "Approximate algorithm must be relation based");
     if (config.GetSpecialParam<double>("error") == 0.0) {
@@ -126,287 +145,38 @@ TypoMiner<PreciseAlgo, ApproxAlgo>::TypoMiner(Config const& config)
 
     Config precise_config = config;
     precise_config.special_params["error"] = 0.0;
-    relation_ = ColumnLayoutRelationData::CreateFrom(input_generator_, config.is_null_equal_null);
-    input_generator_.Reset();
-    typed_relation_ = model::ColumnLayoutTypedRelationData::CreateFrom(input_generator_,
-                                                                       config.is_null_equal_null);
+    CSVParser input_generator(config.data, config.separator, config.has_header);
+    std::shared_ptr<ColumnLayoutRelationData> relation =
+        ColumnLayoutRelationData::CreateFrom(input_generator, config.is_null_equal_null);
+    input_generator.Reset();
+    auto typed_relation = model::ColumnLayoutTypedRelationData::CreateFrom(
+        input_generator, config.is_null_equal_null);
 
+    double radius;
+    double ratio;
     if (config.HasParam("radius")) {
-        SetRadius(config.GetSpecialParam<double>("radius"));
+        radius = VerifyRadius(config.GetSpecialParam<double>("radius"));
     }
     if (config.HasParam("ratio")) {
-        SetRatio(config.GetSpecialParam<double>("ratio"));
+        ratio = VerifyRatio(config.GetSpecialParam<double>("ratio"));
     } else {
         /* Should be good heuristic. Or set ratio to 1 by default? */
-        SetRatio((relation_->GetNumRows() == 0) ? 1 : 2.0 / relation_->GetNumRows());
+        ratio = (relation->GetNumRows() <= 1) ? 1 : 2.0 / relation->GetNumRows();
     }
 
+    std::unique_ptr<FDAlgorithm> precise_algo;
+    std::unique_ptr<FDAlgorithm> approx_algo;
     if constexpr (std::is_base_of_v<PliBasedFDAlgorithm, PreciseAlgo>) {
-        precise_algo_ = std::make_unique<PreciseAlgo>(relation_, precise_config);
+        precise_algo = std::make_unique<PreciseAlgo>(relation, precise_config);
     } else {
-        precise_algo_ = std::make_unique<PreciseAlgo>(precise_config);
+        precise_algo = std::make_unique<PreciseAlgo>(precise_config);
     }
 
-    approx_algo_ = std::make_unique<ApproxAlgo>(relation_, config);
-}
+    approx_algo = std::make_unique<ApproxAlgo>(relation, config);
 
-template<typename PreciseAlgo, typename ApproxAlgo>
-unsigned long long TypoMiner<PreciseAlgo, ApproxAlgo>::Execute() {
-    auto const start_time = std::chrono::system_clock::now();
-
-    precise_algo_->Execute();
-    approx_algo_->Execute();
-
-    std::list<FD>& precise_fds = precise_algo_->FdList();
-    std::list<FD>& approx_fds = approx_algo_->FdList();
-
-    precise_fds.sort(FDLess);
-    approx_fds.sort(FDLess);
-
-    std::set_difference(approx_fds.begin(), approx_fds.end(),
-                        precise_fds.begin(),
-                        precise_fds.end(),
-                        std::back_inserter(approx_fds_), FDLess);
-
-    auto const elapsed_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now() - start_time);
-
-    return elapsed_milliseconds.count();
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-std::vector<util::PLI::Cluster> TypoMiner<PreciseAlgo, ApproxAlgo>::FindClustersWithTypos(
-    FD const& typos_fd, bool const sort_clusters) {
-    std::vector<util::PLI::Cluster> clusters;
-    std::shared_ptr<util::PLI const> intersection_pli;
-    std::vector<Column const*> const lhs_columns = typos_fd.GetLhs().GetColumns();
-    std::vector<int> const& probing_table =
-        relation_->GetColumnData(typos_fd.GetRhs().GetIndex()).GetProbingTable();
-
-    assert(!lhs_columns.empty());
-
-    for (Column const* col : lhs_columns) {
-        ColumnData const& col_data = relation_->GetColumnData(col->GetIndex());
-        std::shared_ptr<util::PLI const> pli = col_data.GetPliOwnership();
-
-        if (intersection_pli == nullptr) {
-            intersection_pli = pli;
-        } else {
-            intersection_pli = intersection_pli->Intersect(pli.get());
-        }
-    }
-
-    for (util::PLI::Cluster const& cluster : intersection_pli->GetIndex()) {
-        int cluster_rhs_value = -1;
-
-        /* Check if fd has wrong rhs values in this cluster */
-        for (int const tuple_index : cluster) {
-            int const probing_table_value = probing_table[tuple_index];
-
-            if (cluster_rhs_value == -1) {
-                cluster_rhs_value = probing_table_value;
-            } else if (cluster_rhs_value != probing_table_value) {
-                cluster_rhs_value = -1;
-                break;
-            }
-        }
-
-        if (cluster_rhs_value == -1 || (cluster_rhs_value == 0 && cluster.size() != 1)) {
-            /* Actually intersection_pli is owned only by this method most of the time
-             * (when lhs_columns.size() != 1), so we can here move cluster when
-             * lhs_columns.size() != 1. But that leads to more cumbersome and complex code.
-             * So I decided to leave it as it is until we know for sure that this place causes
-             * performance problems.
-             */
-            clusters.push_back(cluster);
-
-            if (sort_clusters) {
-                std::map<int, unsigned> const frequency_map =
-                    CreateFrequencyMap(typos_fd.GetRhs(), clusters.back());
-                std::stable_sort(clusters.back().begin(), clusters.back().end(),
-                                 MakeTuplesByIndicesComparator(frequency_map));
-            }
-        }
-    }
-
-    return clusters;
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-std::vector<typename TypoMiner<PreciseAlgo, ApproxAlgo>::SquashedElement>
-TypoMiner<PreciseAlgo, ApproxAlgo>::SquashCluster(FD const& squash_on,
-                                                  util::PLI::Cluster const& cluster) {
-    std::vector<SquashedElement> squashed;
-    std::vector<int> const& probing_table =
-        relation_->GetColumnData(squash_on.GetRhs().GetIndex()).GetProbingTable();
-
-    if (cluster.empty()) {
-        return squashed;
-    }
-
-    auto prev = cluster.begin();
-    squashed.push_back({ .tuple_index = *prev, .amount = 1});
-
-    for (auto it = std::next(cluster.cbegin()); it != cluster.cend(); ++it) {
-        if (probing_table[*it] == probing_table[*prev]) {
-            squashed.back().amount++;
-        } else {
-            squashed.push_back({ .tuple_index = *it, .amount = 1 });
-        }
-        prev = it;
-    }
-
-    return squashed;
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-void TypoMiner<PreciseAlgo, ApproxAlgo>::SortCluster(FD const& sort_on,
-                                                      util::PLI::Cluster& cluster) const {
-    std::map<int, unsigned> const frequency_map = CreateFrequencyMap(sort_on.GetRhs(), cluster);
-
-    std::stable_sort(cluster.begin(), cluster.end(), MakeTuplesByIndicesComparator(frequency_map));
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-std::vector<util::PLI::Cluster::value_type> TypoMiner<PreciseAlgo, ApproxAlgo>::FindLinesWithTypos(
-    FD const& typos_fd, util::PLI::Cluster const& cluster, double new_radius, double new_ratio) {
-    SetRadius(new_radius);
-    SetRatio(new_ratio);
-    return FindLinesWithTypos(typos_fd, cluster);
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-std::vector<util::PLI::Cluster::value_type> TypoMiner<PreciseAlgo, ApproxAlgo>::FindLinesWithTypos(
-    FD const& typos_fd, util::PLI::Cluster const& cluster) const {
-    std::vector<util::PLI::Cluster::value_type> typos;
-    unsigned long num_of_close_values = 0;
-    Column const& col = typos_fd.GetRhs();
-    model::TypedColumnData const& col_data =
-        typed_relation_->GetColumnData(col.GetIndex());
-    std::vector<int> const& probing_table =
-        relation_->GetColumnData(col.GetIndex()).GetProbingTable();
-    std::vector<std::byte const*> const& data = col_data.GetData();
-    model::Type const& type = col_data.GetType();
-
-    unsigned most_freq_index = GetMostFrequentValueIndex(col, cluster);
-    int most_freq_value = probing_table[most_freq_index];
-
-    if (most_freq_value == 0 || col_data.IsMixed() || !type.IsMetrizable()) {
-        if (ratio_ == 1) {
-            return cluster;
-        }
-        return {};
-    }
-
-    for (util::PLI::Cluster::value_type tuple_index : cluster) {
-        if (most_freq_value == probing_table[tuple_index]) {
-            continue;
-        }
-        if (radius_ == -1 ||
-            ValuesAreClose(data[most_freq_index], data[tuple_index], type)) {
-            num_of_close_values++;
-            typos.push_back(tuple_index);
-        }
-    }
-
-    if (double(num_of_close_values) / col_data.GetNumRows() > ratio_) {
-        return {};
-    }
-
-    return typos;
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-std::vector<typename TypoMiner<PreciseAlgo, ApproxAlgo>::ClusterTyposPair>
-TypoMiner<PreciseAlgo, ApproxAlgo>::FindClustersAndLinesWithTypos(const FD& typos_fd,
-                                                                  const bool sort_clusters) {
-    std::vector<ClusterTyposPair> result;
-    std::vector<util::PLI::Cluster> clusters = FindClustersWithTypos(typos_fd, sort_clusters);
-
-    result.reserve(clusters.size());
-
-    for (auto& cluster : clusters) {
-        TyposVec typos = FindLinesWithTypos(typos_fd, cluster);
-        if (!typos.empty()) {
-            result.emplace_back(std::move(cluster), std::move(typos));
-        }
-    }
-
-    return result;
-}
-template <typename PreciseAlgo, typename ApproxAlgo>
-std::unordered_map<int, unsigned> TypoMiner<PreciseAlgo, ApproxAlgo>::CreateFrequencies(
-    util::PLI::Cluster const& cluster, std::vector<int> const& probing_table) const {
-    std::unordered_map<int, unsigned> frequencies;
-
-    for (int const tuple_index : cluster) {
-        int const probing_table_value = probing_table[tuple_index];
-
-        if (probing_table_value != 0) {
-            frequencies[probing_table_value]++;
-        }
-    }
-
-    return frequencies;
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-unsigned TypoMiner<PreciseAlgo, ApproxAlgo>::GetMostFrequentValueIndex(
-    Column const& cluster_col, util::PLI::Cluster const& cluster) const {
-    assert(!cluster.empty());
-    std::vector<int> const& probing_table =
-        relation_->GetColumnData(cluster_col.GetIndex()).GetProbingTable();
-    std::unordered_map<int, unsigned> frequencies = CreateFrequencies(cluster, probing_table);
-
-    unsigned most_frequent_index = cluster.size();
-    unsigned most_frequent_value = 0;
-    for (int const tuple_index : cluster) {
-        int const probing_table_value = probing_table[tuple_index];
-        unsigned const value = (probing_table_value == 0) ? 1 : frequencies.at(probing_table_value);
-        if (value > most_frequent_value) {
-            most_frequent_value = value;
-            most_frequent_index = tuple_index;
-        }
-    }
-
-    return most_frequent_index;
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-std::map<int, unsigned> TypoMiner<PreciseAlgo, ApproxAlgo>::CreateFrequencyMap(
-    Column const& cluster_col, util::PLI::Cluster const& cluster) const {
-    std::map<int, unsigned> frequency_map;
-    std::vector<int> const& probing_table =
-        relation_->GetColumnData(cluster_col.GetIndex()).GetProbingTable();
-    std::unordered_map<int, unsigned> frequencies = CreateFrequencies(cluster, probing_table);
-
-    for (int const tuple_index : cluster) {
-        int const probing_table_value = probing_table[tuple_index];
-        int const value = (probing_table_value == 0) ? 1 : frequencies.at(probing_table_value);
-        frequency_map[tuple_index] = value;
-    }
-
-    return frequency_map;
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-bool TypoMiner<PreciseAlgo, ApproxAlgo>::FDLess(FD const& l, FD const& r) {
-    if (l.GetLhs() < r.GetLhs()) {
-        return true;
-    } else if (l.GetLhs() == r.GetLhs()) {
-        return l.GetRhs() < r.GetRhs();
-    }
-
-    return false;
-}
-
-template <typename PreciseAlgo, typename ApproxAlgo>
-auto TypoMiner<PreciseAlgo, ApproxAlgo>::MakeTuplesByIndicesComparator(
-    std::map<int, unsigned> const& frequency_map) {
-    return [&frequency_map](int const l, int const r) {
-        return frequency_map.at(l) < frequency_map.at(r);
-    };
+    return std::unique_ptr<TypoMiner>(
+        new TypoMiner(std::move(input_generator), std::move(precise_algo), std::move(approx_algo),
+                      std::move(relation), std::move(typed_relation), radius, ratio));
 }
 
 }  // namespace algos
-

--- a/src/model/ColumnData.h
+++ b/src/model/ColumnData.h
@@ -26,6 +26,9 @@ public:
     int GetProbingTableValue(int tuple_index) const {
         return (*position_list_index_->GetCachedProbingTable())[tuple_index];
     }
+    bool IsSingleton(int tuple_index) const noexcept {
+        return GetProbingTableValue(tuple_index) == util::PLI::singleton_value_id_;
+    }
     util::PositionListIndex const* GetPositionListIndex() const {
         return position_list_index_.get();
     }
@@ -36,5 +39,9 @@ public:
     }
 
     std::string ToString() const final { return "Data for " + column_->ToString(); }
+
+    static bool IsValueSingleton(int value) noexcept {
+        return value == util::PLI::singleton_value_id_;
+    }
 };
 

--- a/src/model/RelationalSchema.h
+++ b/src/model/RelationalSchema.h
@@ -41,6 +41,11 @@ public:
     void AppendColumn(const std::string& col_name);
     void AppendColumn(Column column);
 
+    template <typename Container>
+    boost::dynamic_bitset<> IndicesToBitset(Container const& indices) const;
+    template <typename ForwardIt>
+    boost::dynamic_bitset<> IndicesToBitset(ForwardIt begin, ForwardIt end) const;
+
     std::unordered_set<Vertical> CalculateHittingSet(
         std::vector<Vertical> verticals,
         boost::optional<std::function<bool(Vertical const&)>> pruning_function) const;
@@ -56,5 +61,19 @@ inline bool operator==(RelationalSchema const& l, RelationalSchema const& r) {
 }
 inline bool operator!=(RelationalSchema const& l, RelationalSchema const& r) {
     return !(l == r);
+}
+
+template <typename Container>
+boost::dynamic_bitset<> RelationalSchema::IndicesToBitset(Container const& indices) const {
+    return IndicesToBitset(indices.begin(), indices.end());
+}
+
+template <typename ForwardIt>
+boost::dynamic_bitset<> RelationalSchema::IndicesToBitset(ForwardIt begin, ForwardIt end) const {
+    boost::dynamic_bitset<> bitset(GetNumColumns());
+    for (auto it = begin; it != end; ++it) {
+        bitset.set(*it);
+    }
+    return bitset;
 }
 

--- a/tests/TestTypoMiner.cpp
+++ b/tests/TestTypoMiner.cpp
@@ -70,12 +70,12 @@ struct LinesParam : TestingParam {
           expected(std::move(expected)) {}
 };
 
-static std::unique_ptr<algos::TypoMiner<FDAlgorithm>> CreateTypoMiner(algos::Algo const algo,
-                                                                      algos::StdParamsMap m) {
+static std::unique_ptr<algos::TypoMiner> CreateTypoMiner(algos::Algo const algo,
+                                                         algos::StdParamsMap m) {
     auto typo_miner =
         algos::CreateAlgorithmInstance(algos::AlgoMiningType::typos, algo, std::move(m));
-    auto casted = static_cast<algos::TypoMiner<FDAlgorithm> *>(typo_miner.release());
-    return std::unique_ptr<algos::TypoMiner<FDAlgorithm>>(casted);
+    auto casted = static_cast<algos::TypoMiner*>(typo_miner.release());
+    return std::unique_ptr<algos::TypoMiner>(casted);
 }
 
 static std::string MakeJsonFromFds(std::vector<FdByIndices> const& fds) {


### PR DESCRIPTION
Implements `TypoMiner` methods to find lines in cluster that differ from the most frequent value in a cluster by less than specified epsilon. Extends the clusters finding functionality with a ratio of non-frequent values per cluster parameter that specifies which clusters should be treated as containing typos.