### PR TITLE
Fix `no return statement` warnings in RELEASE build

### DIFF
--- a/src/model/types/EmptyType.h
+++ b/src/model/types/EmptyType.h
@@ -8,7 +8,7 @@ namespace model {
 
 class EmptyType : public virtual Type {
 private:
-    static inline void ThrowUnsupportedOperation() {
+    [[noreturn]] static inline void ThrowUnsupportedOperation() {
         throw std::logic_error("Meaningless operation");
     }
 
@@ -23,13 +23,10 @@ public:
     CompareResult Compare([[maybe_unused]] std::byte const* l,
                           [[maybe_unused]] std::byte const* r) const override {
         ThrowUnsupportedOperation();
-        /* To suppress warning */
-        assert(false);
     }
 
     size_t Hash([[maybe_unused]] std::byte const* value) const override {
         ThrowUnsupportedOperation();
-        assert(false);
     }
 
     [[nodiscard]] size_t GetSize() const noexcept override {

--- a/src/model/types/UndefinedType.h
+++ b/src/model/types/UndefinedType.h
@@ -7,7 +7,7 @@ namespace model {
 
 class UndefinedType final : public EmptyType, public NullType {
 private:
-    static inline void ThrowUnsupportedOperation() {
+    [[noreturn]] static inline void ThrowUnsupportedOperation() {
         throw std::logic_error("Meaningless operation. Use EmptyType or NullType methods directly");
     }
 
@@ -17,19 +17,15 @@ public:
 
     std::string ValueToString([[maybe_unused]] std::byte const* value) const final {
         ThrowUnsupportedOperation();
-        /* To suppress warning */
-        assert(false);
     }
 
     CompareResult Compare([[maybe_unused]] std::byte const* l,
                           [[maybe_unused]] std::byte const* r) const final {
         ThrowUnsupportedOperation();
-        assert(false);
     }
 
     size_t Hash([[maybe_unused]] std::byte const* value) const final {
         ThrowUnsupportedOperation();
-        assert(false);
     }
 
     [[nodiscard]] size_t GetSize() const noexcept final {


### PR DESCRIPTION
Mark method `ThrowUnsupportedOperation()` in `EmptyType` and `UndefinedType` `[[noreturn]]` to suppress warnings in release build.  