### PR TITLE
TypoMiner bug fixes

### DIFF
--- a/src/algorithms/TypoMiner.cpp
+++ b/src/algorithms/TypoMiner.cpp
@@ -114,7 +114,8 @@ std::vector<TypoMiner::SquashedElement> TypoMiner::SquashCluster(
     squashed.push_back({.tuple_index = *prev, .amount = 1});
 
     for (auto it = std::next(cluster.cbegin()); it != cluster.cend(); ++it) {
-        if (probing_table[*it] == probing_table[*prev]) {
+        if (probing_table[*it] != util::PLI::singleton_value_id_ &&
+            probing_table[*it] == probing_table[*prev]) {
             squashed.back().amount++;
         } else {
             squashed.push_back({.tuple_index = *it, .amount = 1});

--- a/src/algorithms/TypoMiner.cpp
+++ b/src/algorithms/TypoMiner.cpp
@@ -151,7 +151,8 @@ std::vector<util::PLI::Cluster::value_type> TypoMiner::FindLinesWithTypos(
     int most_freq_value = probing_table[most_freq_index];
 
     if (ColumnData::IsValueSingleton(most_freq_value) || col_data.IsMixed() ||
-        !type.IsMetrizable()) {
+        !type.IsMetrizable() || col_data.IsEmpty(most_freq_index) ||
+        col_data.IsNullOrEmpty(most_freq_index)) {
         if (ratio_ == 1) {
             return cluster;
         }
@@ -163,7 +164,11 @@ std::vector<util::PLI::Cluster::value_type> TypoMiner::FindLinesWithTypos(
     std::vector<std::byte const*> const& data = col_data.GetData();
 
     for (util::PLI::Cluster::value_type tuple_index : cluster) {
-        if (most_freq_value == probing_table[tuple_index]) {
+        /* Temporary ignoring NULL or empty values. Maybe it should be decided by some parameter
+         * if NULL (empty) value is close to any non-NULL (non-empty) or not (as in metric
+         * dependecies).
+         */
+        if (most_freq_value == probing_table[tuple_index] || col_data.IsNullOrEmpty(tuple_index)) {
             continue;
         }
         if (radius_ == -1 || ValuesAreClose(data[most_freq_index], data[tuple_index], type)) {

--- a/src/model/TypedColumnData.h
+++ b/src/model/TypedColumnData.h
@@ -101,6 +101,10 @@ public:
         }
     }
 
+    bool IsNullOrEmpty(unsigned int index) const noexcept {
+        return IsNull(index) || IsEmpty(index);
+    }
+
     TypeId GetValueTypeId(unsigned int index) const noexcept {
         TypeId const type_id = type_->GetTypeId();
         if (type_id == +TypeId::kMixed) {

--- a/tests/TestTypoMiner.cpp
+++ b/tests/TestTypoMiner.cpp
@@ -154,6 +154,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         /* Expected fds should be sorted by lhs */
         FDsParam({{1, 2}}, "SimpleTypos.csv", ',', true, true, -1, 0.05, 0),
+        FDsParam({{0, 1}, {0, 2}, {1, 2}, {0}}, "SimpleTypos.csv", ',', true, true, -1, 0.81, 0),
         FDsParam({{0, 1}, {1, 2}}, "SimpleTypos.csv", ',', true, true, -1, 0.1, 0)));
 
 
@@ -194,7 +195,13 @@ INSTANTIATE_TEST_SUITE_P(
                       "SimpleTypos.csv", ',', true, true, -1, 0.05, 0),
         ClustersParam({ {FdByIndices{0, 1}, {util::PLI::Cluster{4, 0, 1, 5, 6}}},
                         {FdByIndices{1, 2}, {util::PLI::Cluster{7, 9}}} },
-                      "SimpleTypos.csv", ',', true, true, -1, 0.1, 0)));
+                      "SimpleTypos.csv", ',', true, true, -1, 0.1, 0),
+        ClustersParam({ {FdByIndices{0, 1}, {util::PLI::Cluster{4, 0, 1, 5, 6}}},
+                        {FdByIndices{1, 2}, {util::PLI::Cluster{7, 9}}},
+                        {FdByIndices{0, 2}, {util::PLI::Cluster{4, 0, 1, 5, 6},
+                                             util::PLI::Cluster{7, 9}}},
+                        {FdByIndices{0}, {util::PLI::Cluster{8, 2, 3, 7, 9, 0, 1, 4, 5, 6}}}},
+                      "SimpleTypos.csv", ',', true, true, -1, 0.81, 0)));
 
 
 class LinesWithTyposMiningTest : public ::testing::TestWithParam<LinesParam> {};


### PR DESCRIPTION
Fixes several bugs in `TypoMiner`:
- Incorrect processing of unique consecutive values in `TypoMiner::SquashCluster`;
- Incorrect handling of approximate functional dependencies in `TypoMiner::FindClustersWithTypos`;
- Incorrect handling of NULL and empty values in `TypoMiner::FindLinesWithTypos`.

Implements tests to check the reproducibility of these bugs (except for the bug with NULL (empty) values, we first need to decide what behavior will be correct in this case).