### PR TITLE
Better command line parsing

### DIFF
--- a/src/algorithms/AlgoFactory.h
+++ b/src/algorithms/AlgoFactory.h
@@ -7,6 +7,7 @@
 
 #include "Algorithms.h"
 #include "TypoMiner.h"
+#include "ProgramOptionStrings.h"
 
 namespace algos {
 
@@ -54,6 +55,8 @@ using AlgorithmTypesTuple = std::tuple<Depminer, DFD, FastFDs, FDep, Fd_mine, Py
 using ArAlgorithmTuplesType = std::tuple<Apriori>;
 
 namespace details {
+
+namespace posr = program_option_strings;
 
 template <typename AlgorithmBase = Primitive, typename AlgorithmsToSelect = AlgorithmTypesTuple,
           typename EnumType, typename... Args>
@@ -103,12 +106,12 @@ FDAlgorithm::Config CreateFDAlgorithmConfigFromMap(ParamsMap params) {
     FDAlgorithm::Config c;
 
     c.data = std::filesystem::current_path() / "inputData" /
-             ExtractParamFromMap<std::string>(params, "data");
-    c.separator = ExtractParamFromMap<char>(params, "separator");
-    c.has_header = ExtractParamFromMap<bool>(params, "has_header");
-    c.is_null_equal_null = ExtractParamFromMap<bool>(params, "is_null_equal_null");
-    c.max_lhs = ExtractParamFromMap<unsigned int>(params, "max_lhs");
-    c.parallelism = ExtractParamFromMap<ushort>(params, "threads");
+             ExtractParamFromMap<std::string>(params, posr::Data);
+    c.separator = ExtractParamFromMap<char>(params, posr::SeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, posr::HasHeader);
+    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::EqualNulls);
+    c.max_lhs = ExtractParamFromMap<unsigned int>(params, posr::MaximumLhs);
+    c.parallelism = ExtractParamFromMap<ushort>(params, posr::Threads);
 
     /* Is it correct to insert all specified parameters into the algorithm config, and not just the
      * necessary ones? It is definitely simpler, so for now leaving it like this
@@ -131,21 +134,21 @@ ARAlgorithm::Config CreateArAlgorithmConfigFromMap(ParamsMap params) {
     ARAlgorithm::Config c;
 
     c.data = std::filesystem::current_path() / "inputData" /
-             ExtractParamFromMap<std::string>(params, "data");
-    c.separator = ExtractParamFromMap<char>(params, "separator");
-    c.has_header = ExtractParamFromMap<bool>(params, "has_header");
-    c.minsup = ExtractParamFromMap<double>(params, "minsup");
-    c.minconf = ExtractParamFromMap<double>(params, "minconf");
+             ExtractParamFromMap<std::string>(params, posr::Data);
+    c.separator = ExtractParamFromMap<char>(params, posr::SeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, posr::HasHeader);
+    c.minsup = ExtractParamFromMap<double>(params, posr::MinimumSupport);
+    c.minconf = ExtractParamFromMap<double>(params, posr::MinimumConfidence);
 
     std::shared_ptr<model::InputFormat> input_format;
-    auto const input_format_arg = ExtractParamFromMap<std::string>(params, "input_format");
+    auto const input_format_arg = ExtractParamFromMap<std::string>(params, posr::InputFormat);
     if (input_format_arg == "singular") {
-        unsigned const tid_column_index = ExtractParamFromMap<unsigned>(params, "tid_column_index");
+        unsigned const tid_column_index = ExtractParamFromMap<unsigned>(params, posr::TIdColumnIndex);
         unsigned const item_column_index =
-            ExtractParamFromMap<unsigned>(params, "item_column_index");
+            ExtractParamFromMap<unsigned>(params, posr::ItemColumnIndex);
         input_format = std::make_shared<model::Singular>(tid_column_index, item_column_index);
     } else if (input_format_arg == "tabular") {
-        bool const has_header = ExtractParamFromMap<bool>(params, "has_tid");
+        bool const has_header = ExtractParamFromMap<bool>(params, posr::FirstColumnTId);
         input_format = std::make_shared<model::Tabular>(has_header);
     } else {
         throw std::invalid_argument(
@@ -160,23 +163,23 @@ template <typename ParamsMap>
 MetricVerifier::Config CreateMetricVerifierConfigFromMap(ParamsMap params) {
     MetricVerifier::Config c;
 
-    c.parameter = ExtractParamFromMap<double>(params, "parameter");
+    c.parameter = ExtractParamFromMap<double>(params, posr::Parameter);
     if (c.parameter < 0) {
         throw std::invalid_argument("Parameter should not be less than zero.");
     }
-    c.q = ExtractParamFromMap<unsigned>(params, "q");
+    c.q = ExtractParamFromMap<unsigned>(params, posr::QGramLength);
     if (c.q <= 0) {
         throw std::invalid_argument("Q-gram length should be greater than zero.");
     }
     c.data = std::filesystem::current_path() / "inputData" /
-        ExtractParamFromMap<std::string>(params, "data");
-    c.separator = ExtractParamFromMap<char>(params, "separator");
-    c.has_header = ExtractParamFromMap<bool>(params, "has_header");
-    c.is_null_equal_null = ExtractParamFromMap<bool>(params, "is_null_equal_null");
-    c.lhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, "lhs_indices");
-    c.rhs_index = ExtractParamFromMap<unsigned int>(params, "rhs_index");
-    c.metric = ExtractParamFromMap<std::string>(params, "metric");
-    c.dist_to_null_infinity = ExtractParamFromMap<bool>(params, "dist_to_null_infinity");
+        ExtractParamFromMap<std::string>(params, posr::Data);
+    c.separator = ExtractParamFromMap<char>(params, posr::SeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, posr::HasHeader);
+    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::EqualNulls);
+    c.lhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, posr::LhsIndices);
+    c.rhs_index = ExtractParamFromMap<unsigned int>(params, posr::RhsIndex);
+    c.metric = ExtractParamFromMap<std::string>(params, posr::Metric);
+    c.dist_to_null_infinity = ExtractParamFromMap<bool>(params, posr::DistToNullIsInfinity);
     return c;
 }
 

--- a/src/algorithms/TypoMiner.h
+++ b/src/algorithms/TypoMiner.h
@@ -4,6 +4,7 @@
 #include "Primitive.h"
 #include "Pyro.h"
 #include "Types.h"
+#include "ProgramOptionStrings.h"
 
 namespace algos {
 
@@ -139,12 +140,15 @@ template <typename PreciseAlgo, typename ApproxAlgo>
 std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
     static_assert(std::is_base_of_v<PliBasedFDAlgorithm, ApproxAlgo>,
                   "Approximate algorithm must be relation based");
-    if (config.GetSpecialParam<double>("error") == 0.0) {
+
+    namespace posr = program_option_strings;
+
+    if (config.GetSpecialParam<double>(posr::Error) == 0.0) {
         throw std::invalid_argument("Typo mining with error = 0 is meaningless");
     }
 
     Config precise_config = config;
-    precise_config.special_params["error"] = 0.0;
+    precise_config.special_params[posr::Error] = 0.0;
     CSVParser input_generator(config.data, config.separator, config.has_header);
     std::shared_ptr<ColumnLayoutRelationData> relation =
         ColumnLayoutRelationData::CreateFrom(input_generator, config.is_null_equal_null);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,8 +154,8 @@ int main(int argc, char const* argv[]) {
 
     po::options_description ar_tabular_options("AR \"tabular\" input format options");
     ar_tabular_options.add_options()
-        (posr::FirstColumnTId, po::value<bool>(&has_transaction_id)->default_value(false),
-         "indicates whether the first column contains a transaction id")
+        (posr::FirstColumnTId, po::bool_switch(&has_transaction_id),
+         "indicates that the first column contains the transaction IDs")
         ;
 
     ar_options.add(ar_singular_options).add(ar_tabular_options);
@@ -168,7 +168,7 @@ int main(int argc, char const* argv[]) {
         (posr::RhsIndex, po::value<unsigned int>(&rhs_index),
          "RHS column index for metric FD verification")
         (posr::Parameter, po::value<double>(&parameter), "metric FD parameter")
-        (posr::DistToNullIsInfinity, po::value<bool>(&dist_to_null_infinity)->default_value(false),
+        (posr::DistToNullIsInfinity, po::bool_switch(&dist_to_null_infinity),
          "specify whether distance to NULL value is infinity (otherwise it is 0)")
         ;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,8 +11,10 @@
 #include <easylogging++.h>
 
 #include "AlgoFactory.h"
+#include "ProgramOptionStrings.h"
 
 namespace po = boost::program_options;
+namespace posr = program_option_strings;
 
 INITIALIZE_EASYLOGGINGPP
 
@@ -40,7 +42,7 @@ static bool CheckOptions(std::string const& task, std::string const& alg, std::s
         return false;
     }
 
-    if(task == "metric"){
+    if (task == "metric") {
         if (!algos::Metric::_is_valid(metric.c_str())) {
             std::cout << "ERROR: no matching metric."
                          " Available metrics are:\n" +
@@ -102,55 +104,57 @@ int main(int argc, char const* argv[]) {
 
     po::options_description info_options("Desbordante information options");
     info_options.add_options()
-        ("help", "print the help message and exit")
+        (posr::Help, "print the help message and exit")
         // --version, if needed, goes here too
         ;
 
     po::options_description general_options("General options");
     general_options.add_options()
-        ("task", po::value<std::string>(&task), task_desc.c_str())
-        ("algo", po::value<std::string>(&algo), algo_desc.c_str())
-        ("data", po::value<std::string>(&dataset),
-         "path to CSV file, relative to ./inputData")
-        ("separator,s", po::value<char>(&separator)->default_value(separator),
-         "CSV separator")
-        ("has_header", po::value<bool>(&has_header)->default_value(has_header),
+        (posr::Task, po::value<std::string>(&task), task_desc.c_str())
+        (posr::Algorithm, po::value<std::string>(&algo), algo_desc.c_str())
+        (posr::Data, po::value<std::string>(&dataset),
+            "path to CSV file, relative to ./inputData")
+        (posr::SeparatorLibArg, po::value<char>(&separator)->default_value(separator),
+            "CSV separator")
+        (posr::HasHeader, po::value<bool>(&has_header)->default_value(has_header),
          "CSV header presence flag [true|false]")
-        ("is_null_equal_null", po::value<bool>(&is_null_equal_null)->default_value(true),
-         "specify whether two nulls should be considered equal")
-        ("threads", po::value<ushort>(&threads)->default_value(threads),
+        (posr::EqualNulls, po::value<bool>(&is_null_equal_null)->default_value(true),
+         "specify whether two NULLs should be considered equal")
+        (posr::Threads, po::value<ushort>(&threads)->default_value(threads),
          "number of threads to use. If 0, then as many threads are used as "
-         "possible.")
+         "the hardware can handle concurrently.")
         ;
 
     po::options_description typos_fd_options("Typo mining/FD options");
     typos_fd_options.add_options()
-        ("error", po::value<double>(&error)->default_value(error),
+        (posr::Error, po::value<double>(&error)->default_value(error),
          "error value for AFD algorithms")
-        ("max_lhs", po::value<unsigned int>(&max_lhs)->default_value(max_lhs),
+        (posr::MaximumLhs, po::value<unsigned int>(&max_lhs)->default_value(max_lhs),
          "max considered LHS size")
-        ("seed", po::value<int>(&seed)->default_value(seed), "RNG seed")
+        (posr::Seed, po::value<int>(&seed)->default_value(seed), "RNG seed")
         ;
 
     po::options_description ar_options("AR options");
     ar_options.add_options()
-        ("minsup", po::value<double>(&minsup), "minimum support value (between 0 and 1)")
-        ("minconf", po::value<double>(&minconf), "minimum confidence value (between 0 and 1)")
-        ("input_format", po::value<string>(&ar_input_format),
+        (posr::MinimumSupport, po::value<double>(&minsup),
+            "minimum support value (between 0 and 1)")
+        (posr::MinimumConfidence, po::value<double>(&minconf),
+            "minimum confidence value (between 0 and 1)")
+        (posr::InputFormat, po::value<string>(&ar_input_format),
          "format of the input dataset. [singular|tabular] for AR mining")
         ;
 
     po::options_description ar_singular_options("AR \"singular\" input format options");
     ar_singular_options.add_options()
-        ("tid_column_index", po::value<unsigned>(&tid_column_index)->default_value(0),
+        (posr::TIdColumnIndex, po::value<unsigned>(&tid_column_index)->default_value(0),
          "index of the column where a TID is stored")
-        ("item_column_index", po::value<unsigned>(&item_column_index)->default_value(1),
+        (posr::ItemColumnIndex, po::value<unsigned>(&item_column_index)->default_value(1),
          "index of the column where an item name is stored")
         ;
 
     po::options_description ar_tabular_options("AR \"tabular\" input format options");
     ar_tabular_options.add_options()
-        ("first_col_tid", po::value<bool>(&has_transaction_id)->default_value(false),
+        (posr::FirstColumnTId, po::value<bool>(&has_transaction_id)->default_value(false),
          "indicates whether the first column contains a transaction id")
         ;
 
@@ -158,19 +162,20 @@ int main(int argc, char const* argv[]) {
 
     po::options_description mfd_options("MFD options");
     mfd_options.add_options()
-        ("metric", po::value<std::string>(&metric), metric_desc.c_str())
-        ("lhs_indices", po::value<std::vector<unsigned int>>(&lhs_indices)->multitoken(),
+        (posr::Metric, po::value<std::string>(&metric), metric_desc.c_str())
+        (posr::LhsIndices, po::value<std::vector<unsigned int>>(&lhs_indices)->multitoken(),
          "LHS column indices for metric FD verification")
-        ("rhs_index", po::value<unsigned int>(&rhs_index),
-         "RHS column indices for metric FD verification")
-        ("parameter", po::value<double>(&parameter), "metric FD parameter")
-        ("dist_to_null_infinity", po::value<bool>(&dist_to_null_infinity)->default_value(false),
+        (posr::RhsIndex, po::value<unsigned int>(&rhs_index),
+         "RHS column index for metric FD verification")
+        (posr::Parameter, po::value<double>(&parameter), "metric FD parameter")
+        (posr::DistToNullIsInfinity, po::value<bool>(&dist_to_null_infinity)->default_value(false),
          "specify whether distance to NULL value is infinity (otherwise it is 0)")
         ;
 
     po::options_description cosine_options("Cosine metric options");
     cosine_options.add_options()
-        ("q", po::value<unsigned int>(&q)->default_value(2), "q-gram length for cosine metric")
+        (posr::QGramLength, po::value<unsigned int>(&q)->default_value(2),
+         "q-gram length for cosine metric")
         ;
 
     mfd_options.add(cosine_options);
@@ -188,7 +193,7 @@ int main(int argc, char const* argv[]) {
         return 0;
     }
 
-    if (vm.count("help"))
+    if (vm.count(posr::Help))
     {
         std::cout << all_options << std::endl;
         return 0;

--- a/src/util/ProgramOptionStrings.h
+++ b/src/util/ProgramOptionStrings.h
@@ -1,0 +1,35 @@
+//
+// Created by Shlyonskikh Alexey on 2022-07-30.
+// https://github.com/BUYT-1
+//
+
+#pragma once
+
+namespace program_option_strings {
+constexpr auto Help = "help";
+constexpr auto Task = "task";
+constexpr auto Algorithm = "algo";
+constexpr auto Data = "data";
+#define SEPARATOR "separator"
+constexpr auto SeparatorConfig = SEPARATOR;
+constexpr auto SeparatorLibArg = SEPARATOR ",s";
+#undef SEPARATOR
+constexpr auto HasHeader = "has_header";
+constexpr auto EqualNulls = "is_null_equal_null";
+constexpr auto Threads = "threads";
+constexpr auto Error = "error";
+constexpr auto MaximumLhs = "max_lhs";
+constexpr auto Seed = "seed";
+constexpr auto MinimumSupport = "minsup";
+constexpr auto MinimumConfidence = "minconf";
+constexpr auto InputFormat = "input_format";
+constexpr auto TIdColumnIndex = "tid_column_index";
+constexpr auto ItemColumnIndex = "item_column_index";
+constexpr auto FirstColumnTId = "has_tid";
+constexpr auto Metric = "metric";
+constexpr auto LhsIndices = "lhs_indices";
+constexpr auto RhsIndex = "rhs_index";
+constexpr auto Parameter = "parameter";
+constexpr auto DistToNullIsInfinity = "dist_to_null_infinity";
+constexpr auto QGramLength = "q";
+}  // namespace program_option_strings

--- a/src/util/ProgramOptionStrings.h
+++ b/src/util/ProgramOptionStrings.h
@@ -8,7 +8,7 @@
 namespace program_option_strings {
 constexpr auto Help = "help";
 constexpr auto Task = "task";
-constexpr auto Algorithm = "algo";
+constexpr auto Algorithm = "algorithm";
 constexpr auto Data = "data";
 #define SEPARATOR "separator"
 constexpr auto SeparatorConfig = SEPARATOR;

--- a/tests/TestAlgoInterfaces.cpp
+++ b/tests/TestAlgoInterfaces.cpp
@@ -6,6 +6,9 @@
 #include <gtest/gtest.h>
 
 #include "Pyro.h"
+#include "ProgramOptionStrings.h"
+
+namespace tests {
 
 using ::testing::ContainerEq;
 
@@ -16,24 +19,23 @@ struct KeysTestParams {
     std::string_view const dataset;
     char const sep;
     bool const has_header;
-    KeysTestParams(std::vector<unsigned int> expected,
-                   std::string_view const dataset,
-                   char const sep = ',',
-                   bool const has_header = true) noexcept
-        : expected(std::move(expected)), dataset(dataset),
-          sep(sep), has_header(has_header) {}
+    KeysTestParams(std::vector<unsigned int> expected, std::string_view const dataset,
+                   char const sep = ',', bool const has_header = true) noexcept
+        : expected(std::move(expected)), dataset(dataset), sep(sep), has_header(has_header) {}
 };
 
 class KeysTest : public ::testing::TestWithParam<KeysTestParams> {};
 
 template<typename AlgoInterface>
 static inline void GetKeysTestImpl(KeysTestParams const& p) {
+    namespace posr = program_option_strings;
+
     auto const path = fs::current_path() / "inputData" / p.dataset;
     std::vector<unsigned int> actual;
     FDAlgorithm::Config c{.data = path,
                           .separator = p.sep,
                           .has_header = p.has_header,
-                          .special_params = {{"seed", 0}, {"error", 0.0}}};
+                          .special_params = {{posr::Seed, 0}, {posr::Error, 0.0}}};
     algos::Pyro pyro(c);
 
     pyro.Execute();
@@ -69,3 +71,4 @@ INSTANTIATE_TEST_SUITE_P(, KeysTest,
                                            KeysTestParams({0, 2}, "CIPublicHighway700.csv"),
                                            KeysTestParams({}, "abalone.csv", ',', false),
                                            KeysTestParams({}, "adult.csv", ';', false)));
+}  // namespace tests

--- a/tests/TestFdMine.cpp
+++ b/tests/TestFdMine.cpp
@@ -11,6 +11,7 @@
 #include "algorithms/TaneX.h"
 #include "algorithms/Fd_mine.h"
 #include "RelationalSchema.h"
+#include "ProgramOptionStrings.h"
 
 using ::testing::ContainerEq, ::testing::Eq;
 
@@ -121,6 +122,8 @@ void MinimizeFDs(std::list<FD>& fd_collection) {
 }
 
 TEST_F(AlgorithmTest, FD_Mine_ReturnsSameAsPyro) {
+    namespace posr = program_option_strings;
+
     auto path = std::filesystem::current_path() / "inputData";
 
     try {
@@ -137,7 +140,7 @@ TEST_F(AlgorithmTest, FD_Mine_ReturnsSameAsPyro) {
             FDAlgorithm::Config c{.data = path / LightDatasets::DatasetName(i),
                                   .separator = LightDatasets::Separator(i),
                                   .has_header = LightDatasets::HasHeader(i),
-                                  .special_params = {{"seed", 0}, {"error", 0.0}}};
+                                  .special_params = {{posr::Seed, 0}, {posr::Error, 0.0}}};
             auto pyro = algos::Pyro(c);
 
             algorithm->Execute();

--- a/tests/TestMetricVerifier.cpp
+++ b/tests/TestMetricVerifier.cpp
@@ -4,8 +4,10 @@
 
 #include "MetricVerifier.h"
 #include "AlgoFactory.h"
+#include "ProgramOptionStrings.h"
 
 namespace tests {
+namespace posr = program_option_strings;
 
 struct MetricVerifyingParams {
     algos::StdParamsMap params;
@@ -21,16 +23,16 @@ struct MetricVerifyingParams {
                           bool const dist_to_null_infinity = false,
                           bool const expected = true,
                           unsigned const q = 2)
-        : params({{"parameter", min_parameter},
-                  {"lhs_indices", lhs_indices},
-                  {"rhs_index", rhs_index},
-                  {"data", dataset},
-                  {"separator", separator},
-                  {"has_header", has_header},
-                  {"is_null_equal_null", true},
-                  {"metric", metric},
-                  {"q", q},
-                  {"dist_to_null_infinity", dist_to_null_infinity}}),
+        : params({{posr::Parameter, min_parameter},
+                  {posr::LhsIndices, lhs_indices},
+                  {posr::RhsIndex, rhs_index},
+                  {posr::Data, dataset},
+                  {posr::SeparatorConfig, separator},
+                  {posr::HasHeader, has_header},
+                  {posr::EqualNulls, true},
+                  {posr::Metric, metric},
+                  {posr::QGramLength, q},
+                  {posr::DistToNullIsInfinity, dist_to_null_infinity}}),
           expected(expected) {}
 };
 
@@ -57,7 +59,7 @@ TEST_P(TestMetricVerifying, DefaultTest) {
     }
     ASSERT_TRUE(GetResult(*verifier));
 
-    double new_parameter = boost::any_cast<double>(params.at("parameter"));
+    double new_parameter = boost::any_cast<double>(params.at(posr::Parameter));
     new_parameter -= 1e-4;
     if (new_parameter < 0) return;
     verifier->SetParameter(new_parameter);

--- a/tests/TestTypoMiner.cpp
+++ b/tests/TestTypoMiner.cpp
@@ -7,8 +7,10 @@
 
 #include "AlgoFactory.h"
 #include "TypoMiner.h"
+#include "ProgramOptionStrings.h"
 
 namespace tests {
+namespace posr = program_option_strings;
 
 struct TestingParam {
     algos::StdParamsMap params;
@@ -16,14 +18,14 @@ struct TestingParam {
     TestingParam(std::string const& dataset,
                  char const separator, bool const has_header, bool const is_null_equal_null,
                  unsigned const max_lhs, double const error, ushort const threads)
-        : params({{"data", dataset},
-                  {"separator", separator},
-                  {"has_header", has_header},
-                  {"is_null_equal_null", is_null_equal_null},
-                  {"max_lhs", max_lhs},
-                  {"error", error},
-                  {"threads", threads},
-                  {"seed", 0}}) {}
+        : params({{posr::Data, dataset},
+                  {posr::SeparatorConfig, separator},
+                  {posr::HasHeader, has_header},
+                  {posr::EqualNulls, is_null_equal_null},
+                  {posr::MaximumLhs, max_lhs},
+                  {posr::Error, error},
+                  {posr::Threads, threads},
+                  {posr::Seed, 0}}) {}
 };
 
 /* FD represented as vector where all elements except last are lhs indices and

--- a/tests/TestingUtils.h
+++ b/tests/TestingUtils.h
@@ -7,14 +7,18 @@
 
 #include <filesystem>
 
+#include "ProgramOptionStrings.h"
+
 template <typename T>
 class AlgorithmTest : public LightDatasets, public HeavyDatasets, public ::testing::Test {
 protected:
     std::unique_ptr<FDAlgorithm> CreateAlgorithmInstance(
         std::filesystem::path const& path, char separator = ',', bool has_header = true) {
+        namespace posr = program_option_strings;
+
         FDAlgorithm::Config c{ .data = path, .separator = separator, .has_header = has_header };
-        c.special_params["error"] = 0.0;
-        c.special_params["seed"] = 0;
+        c.special_params[posr::Error] = 0.0;
+        c.special_params[posr::Seed] = 0;
         return std::make_unique<T>(c);
     }
 };


### PR DESCRIPTION
Changes:

- Split the command line arguments into different groups (easier to read for the user and programmer alike)
- Use constants for command line argument strings (easier maintenance)
- Use bool_switch for some arguments (more intuitive)