### PR TITLE
Dataset stream interface

### DIFF
--- a/src/algorithms/aidfd/aid.cpp
+++ b/src/algorithms/aidfd/aid.cpp
@@ -223,8 +223,8 @@ void Aid::LoadData() {
         this->schema_->AppendColumn(column_name);
     }
 
-    while (input_generator_->HasLines()) {
-        const std::vector<std::string>& next_line = input_generator_->GetNextLine();
+    while (input_generator_->HasNextRow()) {
+        const std::vector<std::string>& next_line = input_generator_->GetNextRow();
         if (next_line.empty()) {
             break;
         }

--- a/src/algorithms/aidfd/aid.cpp
+++ b/src/algorithms/aidfd/aid.cpp
@@ -210,21 +210,21 @@ void Aid::InvertNegativeCover() {
 }
 
 void Aid::LoadData() {
-    this->number_of_attributes_ = input_generator_.GetNumberOfColumns();
+    this->number_of_attributes_ = input_generator_->GetNumberOfColumns();
     if (this->number_of_attributes_ == 0) {
         throw std::runtime_error("Unable to work on empty dataset. Check data file");
     }
 
-    this->schema_ = std::make_unique<RelationalSchema>(input_generator_.GetRelationName(), true);
+    this->schema_ = std::make_unique<RelationalSchema>(input_generator_->GetRelationName(), true);
 
     for (size_t i = 0; i < this->number_of_attributes_; ++i) {
         const std::basic_string<char>& column_name =
-            input_generator_.GetColumnName(static_cast<int>(i));
+            input_generator_->GetColumnName(static_cast<int>(i));
         this->schema_->AppendColumn(column_name);
     }
 
-    while (input_generator_.HasLines()) {
-        const std::vector<std::string>& next_line = input_generator_.GetNextLine();
+    while (input_generator_->HasLines()) {
+        const std::vector<std::string>& next_line = input_generator_->GetNextLine();
         if (next_line.empty()) {
             break;
         }

--- a/src/algorithms/aidfd/aid.cpp
+++ b/src/algorithms/aidfd/aid.cpp
@@ -223,8 +223,8 @@ void Aid::LoadData() {
         this->schema_->AppendColumn(column_name);
     }
 
-    while (input_generator_.GetHasNext()) {
-        const std::vector<std::string>& next_line = input_generator_.ParseNext();
+    while (input_generator_.HasLines()) {
+        const std::vector<std::string>& next_line = input_generator_.GetNextLine();
         if (next_line.empty()) {
             break;
         }

--- a/src/algorithms/aidfd/aid.cpp
+++ b/src/algorithms/aidfd/aid.cpp
@@ -212,7 +212,7 @@ void Aid::InvertNegativeCover() {
 void Aid::LoadData() {
     this->number_of_attributes_ = input_generator_->GetNumberOfColumns();
     if (this->number_of_attributes_ == 0) {
-        throw std::runtime_error("Unable to work on empty dataset. Check data file");
+        throw std::runtime_error("Unable to work on an empty dataset.");
     }
 
     this->schema_ = std::make_unique<RelationalSchema>(input_generator_->GetRelationName(), true);

--- a/src/algorithms/algo_factory.h
+++ b/src/algorithms/algo_factory.h
@@ -107,12 +107,12 @@ FDAlgorithm::Config CreateFDAlgorithmConfigFromMap(ParamsMap params) {
     FDAlgorithm::Config c;
 
     c.data = std::filesystem::current_path() / "input_data" /
-             ExtractParamFromMap<std::string>(params, posr::Data);
-    c.separator = ExtractParamFromMap<char>(params, posr::SeparatorConfig);
-    c.has_header = ExtractParamFromMap<bool>(params, posr::HasHeader);
-    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::EqualNulls);
-    c.max_lhs = ExtractParamFromMap<unsigned int>(params, posr::MaximumLhs);
-    c.parallelism = ExtractParamFromMap<ushort>(params, posr::Threads);
+             ExtractParamFromMap<std::string>(params, posr::kData);
+    c.separator = ExtractParamFromMap<char>(params, posr::kSeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, posr::kHasHeader);
+    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::kEqualNulls);
+    c.max_lhs = ExtractParamFromMap<unsigned int>(params, posr::kMaximumLhs);
+    c.parallelism = ExtractParamFromMap<ushort>(params, posr::kThreads);
 
     /* Is it correct to insert all specified parameters into the algorithm config, and not just the
      * necessary ones? It is definitely simpler, so for now leaving it like this
@@ -135,21 +135,21 @@ ARAlgorithm::Config CreateArAlgorithmConfigFromMap(ParamsMap params) {
     ARAlgorithm::Config c;
 
     c.data = std::filesystem::current_path() / "input_data" /
-             ExtractParamFromMap<std::string>(params, posr::Data);
-    c.separator = ExtractParamFromMap<char>(params, posr::SeparatorConfig);
-    c.has_header = ExtractParamFromMap<bool>(params, posr::HasHeader);
-    c.minsup = ExtractParamFromMap<double>(params, posr::MinimumSupport);
-    c.minconf = ExtractParamFromMap<double>(params, posr::MinimumConfidence);
+             ExtractParamFromMap<std::string>(params, posr::kData);
+    c.separator = ExtractParamFromMap<char>(params, posr::kSeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, posr::kHasHeader);
+    c.minsup = ExtractParamFromMap<double>(params, posr::kMinimumSupport);
+    c.minconf = ExtractParamFromMap<double>(params, posr::kMinimumConfidence);
 
     std::shared_ptr<model::InputFormat> input_format;
-    auto const input_format_arg = ExtractParamFromMap<std::string>(params, posr::InputFormat);
+    auto const input_format_arg = ExtractParamFromMap<std::string>(params, posr::kInputFormat);
     if (input_format_arg == "singular") {
-        unsigned const tid_column_index = ExtractParamFromMap<unsigned>(params, posr::TIdColumnIndex);
+        unsigned const tid_column_index = ExtractParamFromMap<unsigned>(params, posr::kTIdColumnIndex);
         unsigned const item_column_index =
-            ExtractParamFromMap<unsigned>(params, posr::ItemColumnIndex);
+            ExtractParamFromMap<unsigned>(params, posr::kItemColumnIndex);
         input_format = std::make_shared<model::Singular>(tid_column_index, item_column_index);
     } else if (input_format_arg == "tabular") {
-        bool const has_header = ExtractParamFromMap<bool>(params, posr::FirstColumnTId);
+        bool const has_header = ExtractParamFromMap<bool>(params, posr::kFirstColumnTId);
         input_format = std::make_shared<model::Tabular>(has_header);
     } else {
         throw std::invalid_argument(
@@ -164,34 +164,34 @@ template <typename ParamsMap>
 MetricVerifier::Config CreateMetricVerifierConfigFromMap(ParamsMap params) {
     MetricVerifier::Config c;
 
-    c.parameter = ExtractParamFromMap<long double>(params, posr::Parameter);
+    c.parameter = ExtractParamFromMap<long double>(params, posr::kParameter);
     if (c.parameter < 0) {
         throw std::invalid_argument("Parameter should not be less than zero.");
     }
-    c.q = ExtractParamFromMap<unsigned>(params, posr::QGramLength);
+    c.q = ExtractParamFromMap<unsigned>(params, posr::kQGramLength);
     if (c.q <= 0) {
         throw std::invalid_argument("Q-gram length should be greater than zero.");
     }
     c.data = std::filesystem::current_path() / "input_data" /
-        ExtractParamFromMap<std::string>(params, posr::Data);
-    c.separator = ExtractParamFromMap<char>(params, posr::SeparatorConfig);
-    c.has_header = ExtractParamFromMap<bool>(params, posr::HasHeader);
-    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::EqualNulls);
-    c.lhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, posr::LhsIndices);
-    c.rhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, posr::RhsIndices);
+        ExtractParamFromMap<std::string>(params, posr::kData);
+    c.separator = ExtractParamFromMap<char>(params, posr::kSeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, posr::kHasHeader);
+    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::kEqualNulls);
+    c.lhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, posr::kLhsIndices);
+    c.rhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, posr::kRhsIndices);
     
-    c.metric = ExtractParamFromMap<std::string>(params, posr::Metric);
+    c.metric = ExtractParamFromMap<std::string>(params, posr::kMetric);
     if (c.rhs_indices.size() > 1 && c.metric != "euclidean") {
         throw std::invalid_argument(
             "More than one RHS columns are only allowed for \"euclidean\" metric.");
     }
     if (c.metric != "euclidean" || c.rhs_indices.size() != 1) {
-        c.algo = ExtractParamFromMap<std::string>(params, posr::MetricAlgorithm);
+        c.algo = ExtractParamFromMap<std::string>(params, posr::kMetricAlgorithm);
     }
     if (c.rhs_indices.size() != 2 && c.algo == "calipers") {
         throw std::invalid_argument("\"calipers\" algo is only available for 2 dimensions.");
     }
-    c.dist_to_null_infinity = ExtractParamFromMap<bool>(params, posr::DistToNullIsInfinity);
+    c.dist_to_null_infinity = ExtractParamFromMap<bool>(params, posr::kDistToNullIsInfinity);
     return c;
 }
 

--- a/src/algorithms/ar_algorithm.cpp
+++ b/src/algorithms/ar_algorithm.cpp
@@ -10,7 +10,7 @@ namespace algos {
 unsigned long long ARAlgorithm::Execute() {
     transactional_data_ = model::TransactionalData::CreateFrom(*input_generator_, *input_format_);
     if (transactional_data_->GetNumTransactions() == 0) {
-        throw std::runtime_error("Got an empty .csv file: AR mining is meaningless.");
+        throw std::runtime_error("Got an empty dataset: AR mining is meaningless.");
     }
 
     auto time = FindFrequent();

--- a/src/algorithms/ar_algorithm.cpp
+++ b/src/algorithms/ar_algorithm.cpp
@@ -8,7 +8,7 @@
 namespace algos {
 
 unsigned long long ARAlgorithm::Execute() {
-    transactional_data_ = model::TransactionalData::CreateFrom(input_generator_, *input_format_);
+    transactional_data_ = model::TransactionalData::CreateFrom(*input_generator_, *input_format_);
     if (transactional_data_->GetNumTransactions() == 0) {
         throw std::runtime_error("Got an empty .csv file: AR mining is meaningless.");
     }

--- a/src/algorithms/depminer/depminer.h
+++ b/src/algorithms/depminer/depminer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "csv_parser.h"
 #include "fd_algorithm.h"
 #include "pli_based_fd_algorithm.h"
 #include "depminer/cmax_set.h"

--- a/src/algorithms/fd_algorithm.cpp
+++ b/src/algorithms/fd_algorithm.cpp
@@ -42,7 +42,7 @@ std::vector<Column const*> FDAlgorithm::GetKeys() const {
     std::vector<Column const*> keys;
     std::map<Column const*, size_t> fds_count_per_col;
     unsigned int cols_of_equal_values = 0;
-    size_t const number_of_cols = input_generator_.GetNumberOfColumns();
+    size_t const number_of_cols = input_generator_->GetNumberOfColumns();
 
     for (FD const& fd : fd_collection_) {
         Vertical const& lhs = fd.GetLhs();

--- a/src/algorithms/fd_algorithm.h
+++ b/src/algorithms/fd_algorithm.h
@@ -6,7 +6,6 @@
 
 #include <boost/any.hpp>
 
-#include "csv_parser.h"
 #include "fd.h"
 #include "primitive.h"
 

--- a/src/algorithms/fd_mine.h
+++ b/src/algorithms/fd_mine.h
@@ -4,7 +4,6 @@
 #include <filesystem>
 #include <set>
 
-#include "csv_parser.h"
 #include "column_combination.h"
 #include "column_layout_relation_data.h"
 #include "pli_based_fd_algorithm.h"

--- a/src/algorithms/fdep/fdep.cpp
+++ b/src/algorithms/fdep/fdep.cpp
@@ -105,22 +105,22 @@ void FDep::SpecializePositiveCover(std::bitset<FDTreeElement::kMaxAttrNum> const
 }
 
 void FDep::LoadData() {
-    this->number_attributes_ = input_generator_.GetNumberOfColumns();
+    this->number_attributes_ = input_generator_->GetNumberOfColumns();
     if (this->number_attributes_ == 0) {
         throw std::runtime_error("Unable to work on empty dataset. Check data file");
     }
     this->column_names_.resize(this->number_attributes_);
 
-    this->schema_ = std::make_unique<RelationalSchema>(input_generator_.GetRelationName(), true);
+    this->schema_ = std::make_unique<RelationalSchema>(input_generator_->GetRelationName(), true);
 
     for (size_t i = 0; i < this->number_attributes_; ++i) {
-        this->column_names_[i] = input_generator_.GetColumnName(static_cast<int>(i));
+        this->column_names_[i] = input_generator_->GetColumnName(static_cast<int>(i));
         this->schema_->AppendColumn(this->column_names_[i]);
     }
 
     std::vector<std::string> next_line;
-    while (input_generator_.HasLines()) {
-        next_line = input_generator_.GetNextLine();
+    while (input_generator_->HasLines()) {
+        next_line = input_generator_->GetNextLine();
         if (next_line.empty()) break;
         this->tuples_.emplace_back(std::vector<size_t>(this->number_attributes_));
         for (size_t i = 0; i < this->number_attributes_; ++i) {

--- a/src/algorithms/fdep/fdep.cpp
+++ b/src/algorithms/fdep/fdep.cpp
@@ -119,8 +119,8 @@ void FDep::LoadData() {
     }
 
     std::vector<std::string> next_line;
-    while (input_generator_.GetHasNext()) {
-        next_line = input_generator_.ParseNext();
+    while (input_generator_.HasLines()) {
+        next_line = input_generator_.GetNextLine();
         if (next_line.empty()) break;
         this->tuples_.emplace_back(std::vector<size_t>(this->number_attributes_));
         for (size_t i = 0; i < this->number_attributes_; ++i) {

--- a/src/algorithms/fdep/fdep.cpp
+++ b/src/algorithms/fdep/fdep.cpp
@@ -119,8 +119,8 @@ void FDep::LoadData() {
     }
 
     std::vector<std::string> next_line;
-    while (input_generator_->HasLines()) {
-        next_line = input_generator_->GetNextLine();
+    while (input_generator_->HasNextRow()) {
+        next_line = input_generator_->GetNextRow();
         if (next_line.empty()) break;
         this->tuples_.emplace_back(std::vector<size_t>(this->number_attributes_));
         for (size_t i = 0; i < this->number_attributes_; ++i) {

--- a/src/algorithms/fdep/fdep.cpp
+++ b/src/algorithms/fdep/fdep.cpp
@@ -107,7 +107,7 @@ void FDep::SpecializePositiveCover(std::bitset<FDTreeElement::kMaxAttrNum> const
 void FDep::LoadData() {
     this->number_attributes_ = input_generator_->GetNumberOfColumns();
     if (this->number_attributes_ == 0) {
-        throw std::runtime_error("Unable to work on empty dataset. Check data file");
+        throw std::runtime_error("Unable to work on an empty dataset.");
     }
     this->column_names_.resize(this->number_attributes_);
 

--- a/src/algorithms/fdep/fdep.h
+++ b/src/algorithms/fdep/fdep.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 
-#include "csv_parser.h"
 #include "fd_algorithm.h"
 #include "fd_tree_element.h"
 #include "relation_data.h"

--- a/src/algorithms/metric_verifier.cpp
+++ b/src/algorithms/metric_verifier.cpp
@@ -69,7 +69,7 @@ unsigned long long MetricVerifier::Execute() {
 
 void MetricVerifier::ValidateParameters() const {
     if (relation_->GetColumnData().empty()) {
-        throw std::runtime_error("Got an empty .csv file: metric FD verifying is meaningless.");
+        throw std::runtime_error("Got an empty dataset: metric FD verifying is meaningless.");
     }
 
     size_t cols_count = relation_->GetSchema()->GetNumColumns();

--- a/src/algorithms/metric_verifier.cpp
+++ b/src/algorithms/metric_verifier.cpp
@@ -26,10 +26,10 @@ MetricVerifier::MetricVerifier(Config const& config)
         algo_ = MetricAlgo::_from_string(config.algo.c_str());
     }
     relation_ =
-        ColumnLayoutRelationData::CreateFrom(input_generator_, config.is_null_equal_null);
-    input_generator_.Reset();
+        ColumnLayoutRelationData::CreateFrom(*input_generator_, config.is_null_equal_null);
+    input_generator_->Reset();
     typed_relation_ =
-        model::ColumnLayoutTypedRelationData::CreateFrom(input_generator_,
+        model::ColumnLayoutTypedRelationData::CreateFrom(*input_generator_,
                                                          config.is_null_equal_null);
 }
 

--- a/src/algorithms/pli_based_fd_algorithm.cpp
+++ b/src/algorithms/pli_based_fd_algorithm.cpp
@@ -3,7 +3,7 @@
 void PliBasedFDAlgorithm::Initialize() {
     if (relation_ == nullptr) {
         relation_ =
-            ColumnLayoutRelationData::CreateFrom(input_generator_, config_.is_null_equal_null);
+            ColumnLayoutRelationData::CreateFrom(*input_generator_, config_.is_null_equal_null);
     }
 
     if (relation_->GetColumnData().empty()) {

--- a/src/algorithms/pli_based_fd_algorithm.cpp
+++ b/src/algorithms/pli_based_fd_algorithm.cpp
@@ -7,7 +7,7 @@ void PliBasedFDAlgorithm::Initialize() {
     }
 
     if (relation_->GetColumnData().empty()) {
-        throw std::runtime_error("Got an empty .csv file: FD mining is meaningless.");
+        throw std::runtime_error("Got an empty dataset: FD mining is meaningless.");
     }
 }
 

--- a/src/algorithms/pli_based_fd_algorithm.h
+++ b/src/algorithms/pli_based_fd_algorithm.h
@@ -13,7 +13,8 @@ protected:
     std::shared_ptr<ColumnLayoutRelationData> relation_;
 
     ColumnLayoutRelationData const& GetRelation() const noexcept {
-        // GetRelation should be called after input file is parsed i.e. after algorithm execution
+        // GetRelation should be called after the dataset has been parsed, i.e. after algorithm
+        // execution
         assert(relation_ != nullptr);
         return *relation_;
     }

--- a/src/algorithms/primitive.h
+++ b/src/algorithms/primitive.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "idataset_stream.h"
 #include "csv_parser.h"
 
 namespace algos {
@@ -17,7 +18,7 @@ private:
     uint8_t cur_phase_id_ = 0;
 
 protected:
-    std::unique_ptr<CSVParser> input_generator_;
+    std::unique_ptr<model::IDatasetStream> input_generator_;
     /* Vector of names of algorithm phases, should be initialized in a constructor
      * if algorithm has more than one phase. This vector is used to determine the
      * total number of phases.
@@ -41,7 +42,7 @@ public:
 
     explicit Primitive(std::vector<std::string_view> phase_names)
         : phase_names_(std::move(phase_names)) {}
-    Primitive(std::unique_ptr<CSVParser> input_generator_ptr, std::vector<std::string_view> phase_names)
+    Primitive(std::unique_ptr<model::IDatasetStream> input_generator_ptr, std::vector<std::string_view> phase_names)
         : input_generator_(std::move(input_generator_ptr)), phase_names_(std::move(phase_names)) {}
     Primitive(std::filesystem::path const& path, char const separator, bool const has_header,
               std::vector<std::string_view> phase_names)

--- a/src/algorithms/primitive.h
+++ b/src/algorithms/primitive.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <mutex>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "csv_parser.h"
@@ -16,7 +17,7 @@ private:
     uint8_t cur_phase_id_ = 0;
 
 protected:
-    CSVParser input_generator_;
+    std::unique_ptr<CSVParser> input_generator_;
     /* Vector of names of algorithm phases, should be initialized in a constructor
      * if algorithm has more than one phase. This vector is used to determine the
      * total number of phases.
@@ -40,11 +41,11 @@ public:
 
     explicit Primitive(std::vector<std::string_view> phase_names)
         : phase_names_(std::move(phase_names)) {}
-    Primitive(CSVParser input_generator, std::vector<std::string_view> phase_names)
-        : input_generator_(std::move(input_generator)), phase_names_(std::move(phase_names)) {}
+    Primitive(std::unique_ptr<CSVParser> input_generator_ptr, std::vector<std::string_view> phase_names)
+        : input_generator_(std::move(input_generator_ptr)), phase_names_(std::move(phase_names)) {}
     Primitive(std::filesystem::path const& path, char const separator, bool const has_header,
               std::vector<std::string_view> phase_names)
-        : input_generator_(path, separator, has_header), phase_names_(std::move(phase_names)) {}
+        : input_generator_(std::make_unique<CSVParser>(path, separator, has_header)), phase_names_(std::move(phase_names)) {}
 
     virtual unsigned long long Execute() = 0;
 

--- a/src/algorithms/pyro.h
+++ b/src/algorithms/pyro.h
@@ -3,7 +3,6 @@
 #include <list>
 #include <mutex>
 
-#include "csv_parser.h"
 #include "dependency_consumer.h"
 #include "pli_based_fd_algorithm.h"
 #include "search_space.h"

--- a/src/algorithms/tane.h
+++ b/src/algorithms/tane.h
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "csv_parser.h"
 #include "pli_based_fd_algorithm.h"
 #include "position_list_index.h"
 #include "relation_data.h"

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -158,11 +158,11 @@ std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
 
     double radius;
     double ratio;
-    if (config.HasParam("radius")) {
-        radius = VerifyRadius(config.GetSpecialParam<double>("radius"));
+    if (config.HasParam(posr::kRadius)) {
+        radius = VerifyRadius(config.GetSpecialParam<double>(posr::kRadius));
     }
-    if (config.HasParam("ratio")) {
-        ratio = VerifyRatio(config.GetSpecialParam<double>("ratio"));
+    if (config.HasParam(posr::kRatio)) {
+        ratio = VerifyRatio(config.GetSpecialParam<double>(posr::kRatio));
     } else {
         /* Should be good heuristic. Or set ratio to 1 by default? */
         ratio = (relation->GetNumRows() <= 1) ? 1 : 2.0 / relation->GetNumRows();

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "column_layout_typed_relation_data.h"
+#include "idataset_stream.h"
+#include "csv_parser.h"
 #include "primitive.h"
 #include "pyro.h"
 #include "types.h"
@@ -49,7 +51,8 @@ private:
         assert(type.IsMetrizable());
         return static_cast<model::IMetrizableType const&>(type).Dist(l, r) < radius_;
     }
-    explicit TypoMiner(std::unique_ptr<CSVParser> input_generator, std::unique_ptr<FDAlgorithm> precise_algo,
+    explicit TypoMiner(std::unique_ptr<model::IDatasetStream> input_generator,
+                       std::unique_ptr<FDAlgorithm> precise_algo,
                        std::unique_ptr<FDAlgorithm> approx_algo,
                        std::shared_ptr<ColumnLayoutRelationData> relation,
                        std::unique_ptr<model::ColumnLayoutTypedRelationData> typed_relation,

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -49,7 +49,7 @@ private:
         assert(type.IsMetrizable());
         return static_cast<model::IMetrizableType const&>(type).Dist(l, r) < radius_;
     }
-    explicit TypoMiner(CSVParser input_generator, std::unique_ptr<FDAlgorithm> precise_algo,
+    explicit TypoMiner(std::unique_ptr<CSVParser> input_generator, std::unique_ptr<FDAlgorithm> precise_algo,
                        std::unique_ptr<FDAlgorithm> approx_algo,
                        std::shared_ptr<ColumnLayoutRelationData> relation,
                        std::unique_ptr<model::ColumnLayoutTypedRelationData> typed_relation,
@@ -149,12 +149,12 @@ std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
 
     Config precise_config = config;
     precise_config.special_params[posr::kError] = 0.0;
-    CSVParser input_generator(config.data, config.separator, config.has_header);
+    auto input_generator = std::make_unique<CSVParser>(config.data, config.separator, config.has_header);
     std::shared_ptr<ColumnLayoutRelationData> relation =
-        ColumnLayoutRelationData::CreateFrom(input_generator, config.is_null_equal_null);
-    input_generator.Reset();
+        ColumnLayoutRelationData::CreateFrom(*input_generator, config.is_null_equal_null);
+    input_generator->Reset();
     auto typed_relation = model::ColumnLayoutTypedRelationData::CreateFrom(
-        input_generator, config.is_null_equal_null);
+        *input_generator, config.is_null_equal_null);
 
     double radius;
     double ratio;

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -143,12 +143,12 @@ std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
 
     namespace posr = program_option_strings;
 
-    if (config.GetSpecialParam<double>(posr::Error) == 0.0) {
+    if (config.GetSpecialParam<double>(posr::kError) == 0.0) {
         throw std::invalid_argument("Typo mining with error = 0 is meaningless");
     }
 
     Config precise_config = config;
-    precise_config.special_params[posr::Error] = 0.0;
+    precise_config.special_params[posr::kError] = 0.0;
     CSVParser input_generator(config.data, config.separator, config.has_header);
     std::shared_ptr<ColumnLayoutRelationData> relation =
         ColumnLayoutRelationData::CreateFrom(input_generator, config.is_null_equal_null);

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "column_layout_typed_relation_data.h"
-#include "idataset_stream.h"
 #include "csv_parser.h"
+#include "idataset_stream.h"
 #include "primitive.h"
+#include "program_option_strings.h"
 #include "pyro.h"
 #include "types.h"
-#include "program_option_strings.h"
 
 namespace algos {
 
@@ -41,7 +41,7 @@ private:
     }
 
     std::unordered_map<int, unsigned> CreateFrequencies(
-        util::PLI::Cluster const& cluster, std::vector<int> const& probing_table) const;
+            util::PLI::Cluster const& cluster, std::vector<int> const& probing_table) const;
     std::map<int, unsigned> CreateFrequencyMap(Column const& cluster_col,
                                                util::PLI::Cluster const& cluster) const;
     unsigned GetMostFrequentValueIndex(Column const& cluster_col,
@@ -106,8 +106,8 @@ public:
     TyposVec FindLinesWithTypos(FD const& typos_fd, util::PLI::Cluster const& cluster) const;
     TyposVec FindLinesWithTypos(FD const& typos_fd, util::PLI::Cluster const& cluster,
                                 double new_radius, double new_ratio);
-    std::vector<ClusterTyposPair> FindClustersAndLinesWithTypos(
-        FD const& typos_fd, bool const sort_clusters = true);
+    std::vector<ClusterTyposPair> FindClustersAndLinesWithTypos(FD const& typos_fd,
+                                                                bool const sort_clusters = true);
 
     /* Returns vector of approximate fds only (there are no precise fds) */
     std::vector<FD> const& GetApproxFDs() const noexcept {
@@ -152,12 +152,13 @@ std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
 
     Config precise_config = config;
     precise_config.special_params[posr::kError] = 0.0;
-    auto input_generator = std::make_unique<CSVParser>(config.data, config.separator, config.has_header);
-    std::shared_ptr<ColumnLayoutRelationData> relation =
-        ColumnLayoutRelationData::CreateFrom(*input_generator, config.is_null_equal_null);
+    auto input_generator = std::make_unique<CSVParser>(config.data, config.separator,
+                                                       config.has_header);
+    std::shared_ptr<ColumnLayoutRelationData> relation = ColumnLayoutRelationData::CreateFrom(
+            *input_generator, config.is_null_equal_null);
     input_generator->Reset();
     auto typed_relation = model::ColumnLayoutTypedRelationData::CreateFrom(
-        *input_generator, config.is_null_equal_null);
+            *input_generator, config.is_null_equal_null);
 
     double radius;
     double ratio;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,57 +122,57 @@ int main(int argc, char const* argv[]) {
 
     po::options_description info_options("Desbordante information options");
     info_options.add_options()
-        (posr::Help, "print the help message and exit")
+        (posr::kHelp, "print the help message and exit")
         // --version, if needed, goes here too
         ;
 
     po::options_description general_options("General options");
     general_options.add_options()
-        (posr::Task, po::value<std::string>(&task), task_desc.c_str())
-        (posr::Algorithm, po::value<std::string>(&algo), algo_desc.c_str())
-        (posr::Data, po::value<std::string>(&dataset),
+        (posr::kTask, po::value<std::string>(&task), task_desc.c_str())
+        (posr::kAlgorithm, po::value<std::string>(&algo), algo_desc.c_str())
+        (posr::kData, po::value<std::string>(&dataset),
             "path to CSV file, relative to ./input_data")
-        (posr::SeparatorLibArg, po::value<char>(&separator)->default_value(separator),
+        (posr::kSeparatorLibArg, po::value<char>(&separator)->default_value(separator),
             "CSV separator")
-        (posr::HasHeader, po::value<bool>(&has_header)->default_value(has_header),
+        (posr::kHasHeader, po::value<bool>(&has_header)->default_value(has_header),
          "CSV header presence flag [true|false]")
-        (posr::EqualNulls, po::value<bool>(&is_null_equal_null)->default_value(true),
+        (posr::kEqualNulls, po::value<bool>(&is_null_equal_null)->default_value(true),
          "specify whether two NULLs should be considered equal")
-        (posr::Threads, po::value<ushort>(&threads)->default_value(threads),
+        (posr::kThreads, po::value<ushort>(&threads)->default_value(threads),
          "number of threads to use. If 0, then as many threads are used as "
          "the hardware can handle concurrently.")
         ;
 
     po::options_description typos_fd_options("Typo mining/FD options");
     typos_fd_options.add_options()
-        (posr::Error, po::value<double>(&error)->default_value(error),
+        (posr::kError, po::value<double>(&error)->default_value(error),
          "error value for AFD algorithms")
-        (posr::MaximumLhs, po::value<unsigned int>(&max_lhs)->default_value(max_lhs),
+        (posr::kMaximumLhs, po::value<unsigned int>(&max_lhs)->default_value(max_lhs),
          "max considered LHS size")
-        (posr::Seed, po::value<int>(&seed)->default_value(seed), "RNG seed")
+        (posr::kSeed, po::value<int>(&seed)->default_value(seed), "RNG seed")
         ;
 
     po::options_description ar_options("AR options");
     ar_options.add_options()
-        (posr::MinimumSupport, po::value<double>(&minsup),
+        (posr::kMinimumSupport, po::value<double>(&minsup),
             "minimum support value (between 0 and 1)")
-        (posr::MinimumConfidence, po::value<double>(&minconf),
+        (posr::kMinimumConfidence, po::value<double>(&minconf),
             "minimum confidence value (between 0 and 1)")
-        (posr::InputFormat, po::value<string>(&ar_input_format),
+        (posr::kInputFormat, po::value<string>(&ar_input_format),
          "format of the input dataset. [singular|tabular] for AR mining")
         ;
 
     po::options_description ar_singular_options("AR \"singular\" input format options");
     ar_singular_options.add_options()
-        (posr::TIdColumnIndex, po::value<unsigned>(&tid_column_index)->default_value(0),
+        (posr::kTIdColumnIndex, po::value<unsigned>(&tid_column_index)->default_value(0),
          "index of the column where a TID is stored")
-        (posr::ItemColumnIndex, po::value<unsigned>(&item_column_index)->default_value(1),
+        (posr::kItemColumnIndex, po::value<unsigned>(&item_column_index)->default_value(1),
          "index of the column where an item name is stored")
         ;
 
     po::options_description ar_tabular_options("AR \"tabular\" input format options");
     ar_tabular_options.add_options()
-        (posr::FirstColumnTId, po::bool_switch(&has_transaction_id),
+        (posr::kFirstColumnTId, po::bool_switch(&has_transaction_id),
          "indicates that the first column contains the transaction IDs")
         ;
 
@@ -180,20 +180,20 @@ int main(int argc, char const* argv[]) {
 
     po::options_description mfd_options("MFD options");
     mfd_options.add_options()
-        (posr::Metric, po::value<std::string>(&metric), metric_desc.c_str())
-        (posr::MetricAlgorithm, po::value<std::string>(&metric_algo), metric_algo_desc.c_str())
-        (posr::LhsIndices, po::value<std::vector<unsigned int>>(&lhs_indices)->multitoken(),
+        (posr::kMetric, po::value<std::string>(&metric), metric_desc.c_str())
+        (posr::kMetricAlgorithm, po::value<std::string>(&metric_algo), metric_algo_desc.c_str())
+        (posr::kLhsIndices, po::value<std::vector<unsigned int>>(&lhs_indices)->multitoken(),
          "LHS column indices for metric FD verification")
-        (posr::RhsIndices, po::value<std::vector<unsigned int>>(&rhs_indices)->multitoken(),
+        (posr::kRhsIndices, po::value<std::vector<unsigned int>>(&rhs_indices)->multitoken(),
          "RHS column indices for metric FD verification")
-        (posr::Parameter, po::value<long double>(&parameter), "metric FD parameter")
-        (posr::DistToNullIsInfinity, po::bool_switch(&dist_to_null_infinity),
+        (posr::kParameter, po::value<long double>(&parameter), "metric FD parameter")
+        (posr::kDistToNullIsInfinity, po::bool_switch(&dist_to_null_infinity),
          "specify whether distance to NULL value is infinity (otherwise it is 0)")
         ;
 
     po::options_description cosine_options("Cosine metric options");
     cosine_options.add_options()
-        (posr::QGramLength, po::value<unsigned int>(&q)->default_value(2),
+        (posr::kQGramLength, po::value<unsigned int>(&q)->default_value(2),
          "q-gram length for cosine metric")
         ;
 
@@ -212,7 +212,7 @@ int main(int argc, char const* argv[]) {
         return 0;
     }
 
-    if (vm.count(posr::Help))
+    if (vm.count(posr::kHelp))
     {
         std::cout << all_options << std::endl;
         return 0;

--- a/src/model/column_layout_relation_data.cpp
+++ b/src/model/column_layout_relation_data.cpp
@@ -20,7 +20,7 @@ std::vector<int> ColumnLayoutRelationData::GetTuple(int tuple_index) const {
 }
 
 std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
-    model::IDatasetStream& data_stream, bool is_null_eq_null, int max_cols, long max_rows) {
+        model::IDatasetStream& data_stream, bool is_null_eq_null, int max_cols, long max_rows) {
     auto schema = std::make_unique<RelationalSchema>(data_stream.GetRelationName(),
                                                      is_null_eq_null);
     std::unordered_map<std::string, int> value_dictionary;
@@ -81,4 +81,3 @@ std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
 
     return std::make_unique<ColumnLayoutRelationData>(std::move(schema), std::move(column_data));
 }
-

--- a/src/model/column_layout_relation_data.cpp
+++ b/src/model/column_layout_relation_data.cpp
@@ -20,9 +20,8 @@ std::vector<int> ColumnLayoutRelationData::GetTuple(int tuple_index) const {
 }
 
 std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
-    CSVParser& file_input, bool is_null_eq_null, int max_cols, long max_rows) {
-    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(),
-                                                     is_null_eq_null);
+    model::IDatasetStream& file_input, bool is_null_eq_null, int max_cols, long max_rows) {
+    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(), is_null_eq_null);
     std::unordered_map<std::string, int> value_dictionary;
     int next_value_id = 1;
     const int null_value_id = -1;

--- a/src/model/column_layout_relation_data.cpp
+++ b/src/model/column_layout_relation_data.cpp
@@ -31,8 +31,8 @@ std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
     int row_num = 0;
     std::vector<std::string> row;
 
-    while (file_input.GetHasNext()) {
-        row = file_input.ParseNext();
+    while (file_input.HasLines()) {
+        row = file_input.GetNextLine();
 
         if (row.empty() && num_columns == 1) {
             row.emplace_back("");

--- a/src/model/column_layout_relation_data.cpp
+++ b/src/model/column_layout_relation_data.cpp
@@ -21,7 +21,8 @@ std::vector<int> ColumnLayoutRelationData::GetTuple(int tuple_index) const {
 
 std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
     CSVParser& file_input, bool is_null_eq_null, int max_cols, long max_rows) {
-    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(), is_null_eq_null);
+    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(),
+                                                     is_null_eq_null);
     std::unordered_map<std::string, int> value_dictionary;
     int next_value_id = 1;
     const int null_value_id = -1;

--- a/src/model/column_layout_relation_data.cpp
+++ b/src/model/column_layout_relation_data.cpp
@@ -32,8 +32,8 @@ std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
     int row_num = 0;
     std::vector<std::string> row;
 
-    while (data_stream.HasLines()) {
-        row = data_stream.GetNextLine();
+    while (data_stream.HasNextRow()) {
+        row = data_stream.GetNextRow();
 
         if (row.empty() && num_columns == 1) {
             row.emplace_back("");

--- a/src/model/column_layout_relation_data.h
+++ b/src/model/column_layout_relation_data.h
@@ -27,7 +27,7 @@ public:
     }
     [[nodiscard]] std::vector<int> GetTuple(int tuple_index) const;
 
-    static std::unique_ptr<ColumnLayoutRelationData> CreateFrom(model::IDatasetStream& file_input,
+    static std::unique_ptr<ColumnLayoutRelationData> CreateFrom(model::IDatasetStream& data_stream,
                                                                 bool is_null_eq_null,
                                                                 int max_cols = -1,
                                                                 long max_rows = -1);

--- a/src/model/column_layout_relation_data.h
+++ b/src/model/column_layout_relation_data.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "column_data.h"
-#include "csv_parser.h"
+#include "idataset_stream.h"
 #include "relational_schema.h"
 #include "relation_data.h"
 
@@ -27,7 +27,7 @@ public:
     }
     [[nodiscard]] std::vector<int> GetTuple(int tuple_index) const;
 
-    static std::unique_ptr<ColumnLayoutRelationData> CreateFrom(CSVParser& file_input,
+    static std::unique_ptr<ColumnLayoutRelationData> CreateFrom(model::IDatasetStream& file_input,
                                                                 bool is_null_eq_null,
                                                                 int max_cols = -1,
                                                                 long max_rows = -1);

--- a/src/model/column_layout_typed_relation_data.cpp
+++ b/src/model/column_layout_typed_relation_data.cpp
@@ -5,7 +5,7 @@
 namespace model {
 
 std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::CreateFrom(
-    IDatasetStream& data_stream, bool is_null_eq_null, int max_cols, long max_rows) {
+        IDatasetStream& data_stream, bool is_null_eq_null, int max_cols, long max_rows) {
     auto schema = std::make_unique<RelationalSchema>(data_stream.GetRelationName(),
                                                      is_null_eq_null);
     int num_columns = data_stream.GetNumberOfColumns();
@@ -53,7 +53,7 @@ std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::Cr
         Column column(schema.get(), data_stream.GetColumnName(i), i);
         schema->AppendColumn(std::move(column));
         TypedColumnData typed_column_data = model::TypedColumnDataFactory::CreateFrom(
-            schema->GetColumn(i), std::move(columns[i]), is_null_eq_null);
+                schema->GetColumn(i), std::move(columns[i]), is_null_eq_null);
         column_data.emplace_back(std::move(typed_column_data));
     }
 

--- a/src/model/column_layout_typed_relation_data.cpp
+++ b/src/model/column_layout_typed_relation_data.cpp
@@ -6,7 +6,8 @@ namespace model {
 
 std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::CreateFrom(
     CSVParser& file_input, bool is_null_eq_null, int max_cols, long max_rows) {
-    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(), is_null_eq_null);
+    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(),
+                                                     is_null_eq_null);
     int num_columns = file_input.GetNumberOfColumns();
 
     if (max_cols > 0) {

--- a/src/model/column_layout_typed_relation_data.cpp
+++ b/src/model/column_layout_typed_relation_data.cpp
@@ -5,9 +5,10 @@
 namespace model {
 
 std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::CreateFrom(
-    IDatasetStream& file_input, bool is_null_eq_null, int max_cols, long max_rows) {
-    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(), is_null_eq_null);
-    int num_columns = file_input.GetNumberOfColumns();
+    IDatasetStream& data_stream, bool is_null_eq_null, int max_cols, long max_rows) {
+    auto schema = std::make_unique<RelationalSchema>(data_stream.GetRelationName(),
+                                                     is_null_eq_null);
+    int num_columns = data_stream.GetNumberOfColumns();
 
     if (max_cols > 0) {
         num_columns = std::min(num_columns, max_cols);
@@ -20,8 +21,8 @@ std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::Cr
     /* Parsing is very similar to ColumnLayoutRelationData::CreateFrom().
      * Maybe we need column-based parsing in addition to row-based in CSVParser
      * (now IDatasetStream) */
-    while (file_input.HasLines()) {
-        row = file_input.GetNextLine();
+    while (data_stream.HasLines()) {
+        row = data_stream.GetNextLine();
 
         if (row.empty() && num_columns == 1) {
             row.emplace_back("");
@@ -49,7 +50,7 @@ std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::Cr
 
     std::vector<TypedColumnData> column_data;
     for (int i = 0; i < num_columns; ++i) {
-        Column column(schema.get(), file_input.GetColumnName(i), i);
+        Column column(schema.get(), data_stream.GetColumnName(i), i);
         schema->AppendColumn(std::move(column));
         TypedColumnData typed_column_data = model::TypedColumnDataFactory::CreateFrom(
             schema->GetColumn(i), std::move(columns[i]), is_null_eq_null);

--- a/src/model/column_layout_typed_relation_data.cpp
+++ b/src/model/column_layout_typed_relation_data.cpp
@@ -21,8 +21,8 @@ std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::Cr
     /* Parsing is very similar to ColumnLayoutRelationData::CreateFrom().
      * Maybe we need column-based parsing in addition to row-based in CSVParser
      * (now IDatasetStream) */
-    while (data_stream.HasLines()) {
-        row = data_stream.GetNextLine();
+    while (data_stream.HasNextRow()) {
+        row = data_stream.GetNextRow();
 
         if (row.empty() && num_columns == 1) {
             row.emplace_back("");

--- a/src/model/column_layout_typed_relation_data.cpp
+++ b/src/model/column_layout_typed_relation_data.cpp
@@ -19,8 +19,8 @@ std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::Cr
 
     /* Parsing is very similar to ColumnLayoutRelationData::CreateFrom().
      * Maybe we need column-based parsing in addition to row-based in CSVParser */
-    while (file_input.GetHasNext()) {
-        row = file_input.ParseNext();
+    while (file_input.HasLines()) {
+        row = file_input.GetNextLine();
 
         if (row.empty() && num_columns == 1) {
             row.emplace_back("");

--- a/src/model/column_layout_typed_relation_data.cpp
+++ b/src/model/column_layout_typed_relation_data.cpp
@@ -5,9 +5,8 @@
 namespace model {
 
 std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::CreateFrom(
-    CSVParser& file_input, bool is_null_eq_null, int max_cols, long max_rows) {
-    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(),
-                                                     is_null_eq_null);
+    IDatasetStream& file_input, bool is_null_eq_null, int max_cols, long max_rows) {
+    auto schema = std::make_unique<RelationalSchema>(file_input.GetRelationName(), is_null_eq_null);
     int num_columns = file_input.GetNumberOfColumns();
 
     if (max_cols > 0) {
@@ -19,7 +18,8 @@ std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::Cr
     std::vector<std::string> row;
 
     /* Parsing is very similar to ColumnLayoutRelationData::CreateFrom().
-     * Maybe we need column-based parsing in addition to row-based in CSVParser */
+     * Maybe we need column-based parsing in addition to row-based in CSVParser
+     * (now IDatasetStream) */
     while (file_input.HasLines()) {
         row = file_input.GetNextLine();
 

--- a/src/model/column_layout_typed_relation_data.h
+++ b/src/model/column_layout_typed_relation_data.h
@@ -21,10 +21,8 @@ public:
     }
 
     static std::unique_ptr<ColumnLayoutTypedRelationData> CreateFrom(
-        model::IDatasetStream& data_stream,
-        bool is_null_eq_null,
-        int max_cols = -1,
-        long max_rows = -1);
+            model::IDatasetStream& data_stream, bool is_null_eq_null, int max_cols = -1,
+            long max_rows = -1);
 };
 
 }  // namespace model

--- a/src/model/column_layout_typed_relation_data.h
+++ b/src/model/column_layout_typed_relation_data.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "csv_parser.h"
+#include "idataset_stream.h"
 #include "relation_data.h"
 #include "typed_column_data.h"
 
@@ -20,10 +20,11 @@ public:
         }
     }
 
-    static std::unique_ptr<ColumnLayoutTypedRelationData> CreateFrom(CSVParser& file_input,
-                                                                     bool is_null_eq_null,
-                                                                     int max_cols = -1,
-                                                                     long max_rows = -1);
+    static std::unique_ptr<ColumnLayoutTypedRelationData> CreateFrom(
+        model::IDatasetStream& file_input,
+        bool is_null_eq_null,
+        int max_cols = -1,
+        long max_rows = -1);
 };
 
 }  // namespace model

--- a/src/model/column_layout_typed_relation_data.h
+++ b/src/model/column_layout_typed_relation_data.h
@@ -21,7 +21,7 @@ public:
     }
 
     static std::unique_ptr<ColumnLayoutTypedRelationData> CreateFrom(
-        model::IDatasetStream& file_input,
+        model::IDatasetStream& data_stream,
         bool is_null_eq_null,
         int max_cols = -1,
         long max_rows = -1);

--- a/src/model/idataset_stream.h
+++ b/src/model/idataset_stream.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace model {
+
+class IDatasetStream {
+public:
+    virtual std::vector<std::string> GetNextLine() = 0;
+    [[nodiscard]] virtual bool HasLines() const = 0;
+    [[nodiscard]] virtual int GetNumberOfColumns() const = 0;
+    [[nodiscard]] virtual std::string GetColumnName(int index) const = 0;
+    [[nodiscard]] virtual std::string GetRelationName() const = 0;
+    virtual void Reset() = 0;
+    virtual ~IDatasetStream() = default;
+};
+
+}  // namespace model

--- a/src/model/idataset_stream.h
+++ b/src/model/idataset_stream.h
@@ -7,8 +7,8 @@ namespace model {
 
 class IDatasetStream {
 public:
-    virtual std::vector<std::string> GetNextLine() = 0;
-    [[nodiscard]] virtual bool HasLines() const = 0;
+    virtual std::vector<std::string> GetNextRow() = 0;
+    [[nodiscard]] virtual bool HasNextRow() const = 0;
     [[nodiscard]] virtual int GetNumberOfColumns() const = 0;
     [[nodiscard]] virtual std::string GetColumnName(int index) const = 0;
     [[nodiscard]] virtual std::string GetRelationName() const = 0;

--- a/src/model/idataset_stream.h
+++ b/src/model/idataset_stream.h
@@ -9,7 +9,7 @@ class IDatasetStream {
 public:
     virtual std::vector<std::string> GetNextRow() = 0;
     [[nodiscard]] virtual bool HasNextRow() const = 0;
-    [[nodiscard]] virtual int GetNumberOfColumns() const = 0;
+    [[nodiscard]] virtual size_t GetNumberOfColumns() const = 0;
     [[nodiscard]] virtual std::string GetColumnName(int index) const = 0;
     [[nodiscard]] virtual std::string GetRelationName() const = 0;
     virtual void Reset() = 0;

--- a/src/model/transactional_data.cpp
+++ b/src/model/transactional_data.cpp
@@ -6,31 +6,32 @@
 
 namespace model {
 
-std::unique_ptr<TransactionalData> TransactionalData::CreateFrom(IDatasetStream& file_input,
+std::unique_ptr<TransactionalData> TransactionalData::CreateFrom(IDatasetStream& data_stream,
                                                                  InputFormat const& input_type) {
     if (typeid(input_type) == typeid(Singular)) {
-        return TransactionalData::CreateFromSingular(file_input, input_type.tid_column_index(),
+        return TransactionalData::CreateFromSingular(data_stream, input_type.tid_column_index(),
                                                      input_type.item_column_index());
     } else if (typeid(input_type) == typeid(Tabular)) {
-        return TransactionalData::CreateFromTabular(file_input, input_type.tid_presence());
+        return TransactionalData::CreateFromTabular(data_stream, input_type.tid_presence());
     } else {
         throw std::logic_error("This input type is not maintained yet");
     }
 }
 
-std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(IDatasetStream& file_input,
-                                                                         unsigned tid_col_index,
-                                                                         unsigned item_col_index) {
+std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(
+    IDatasetStream& data_stream,
+    unsigned tid_col_index,
+    unsigned item_col_index) {
     std::vector<std::string> item_universe;
     std::unordered_map<std::string, unsigned> item_universe_set;
     std::unordered_map<unsigned, Itemset> transactions;
     unsigned latest_item_id = 0;
 
-    assert(file_input.GetNumberOfColumns() >
+    assert(data_stream.GetNumberOfColumns() >
            static_cast<int>(std::max(tid_col_index, item_col_index)));
 
-    while (file_input.HasLines()) {
-        std::vector<std::string> row = file_input.GetNextLine();
+    while (data_stream.HasLines()) {
+        std::vector<std::string> row = data_stream.GetNextLine();
         if (row.empty()) {
             continue;
         }
@@ -61,7 +62,7 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(IDatase
                                                                     std::move(transactions)));
 }
 
-std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(IDatasetStream& file_input,
+std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(IDatasetStream& data_stream,
                                                                         bool has_tid) {
     std::vector<std::string> item_universe;
     std::unordered_map<std::string, unsigned> item_universe_set;
@@ -69,8 +70,8 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(IDataset
     unsigned latest_item_id = 0;
     unsigned tid = 0;
 
-    while (file_input.HasLines()) {
-        std::vector<std::string> row = file_input.GetNextLine();
+    while (data_stream.HasLines()) {
+        std::vector<std::string> row = data_stream.GetNextLine();
         if (row.empty()) {
             continue;
         }

--- a/src/model/transactional_data.cpp
+++ b/src/model/transactional_data.cpp
@@ -1,11 +1,12 @@
 #include "transactional_data.h"
 
 #include <cassert>
+#include <stdexcept>
 #include <unordered_map>
 
 namespace model {
 
-std::unique_ptr<TransactionalData> TransactionalData::CreateFrom(CSVParser& file_input,
+std::unique_ptr<TransactionalData> TransactionalData::CreateFrom(IDatasetStream& file_input,
                                                                  InputFormat const& input_type) {
     if (typeid(input_type) == typeid(Singular)) {
         return TransactionalData::CreateFromSingular(file_input, input_type.tid_column_index(),
@@ -17,7 +18,7 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFrom(CSVParser& file
     }
 }
 
-std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(CSVParser& file_input,
+std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(IDatasetStream& file_input,
                                                                          unsigned tid_col_index,
                                                                          unsigned item_col_index) {
     std::vector<std::string> item_universe;
@@ -60,7 +61,7 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(CSVPars
                                                                     std::move(transactions)));
 }
 
-std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(CSVParser& file_input,
+std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(IDatasetStream& file_input,
                                                                         bool has_tid) {
     std::vector<std::string> item_universe;
     std::unordered_map<std::string, unsigned> item_universe_set;

--- a/src/model/transactional_data.cpp
+++ b/src/model/transactional_data.cpp
@@ -28,8 +28,8 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(CSVPars
     assert(file_input.GetNumberOfColumns() >
            static_cast<int>(std::max(tid_col_index, item_col_index)));
 
-    while (file_input.GetHasNext()) {
-        std::vector<std::string> row = file_input.ParseNext();
+    while (file_input.HasLines()) {
+        std::vector<std::string> row = file_input.GetNextLine();
         if (row.empty()) {
             continue;
         }
@@ -68,8 +68,8 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(CSVParse
     unsigned latest_item_id = 0;
     unsigned tid = 0;
 
-    while (file_input.GetHasNext()) {
-        std::vector<std::string> row = file_input.ParseNext();
+    while (file_input.HasLines()) {
+        std::vector<std::string> row = file_input.GetNextLine();
         if (row.empty()) {
             continue;
         }

--- a/src/model/transactional_data.cpp
+++ b/src/model/transactional_data.cpp
@@ -30,8 +30,8 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(
     assert(data_stream.GetNumberOfColumns() >
            static_cast<int>(std::max(tid_col_index, item_col_index)));
 
-    while (data_stream.HasLines()) {
-        std::vector<std::string> row = data_stream.GetNextLine();
+    while (data_stream.HasNextRow()) {
+        std::vector<std::string> row = data_stream.GetNextRow();
         if (row.empty()) {
             continue;
         }
@@ -70,8 +70,8 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(IDataset
     unsigned latest_item_id = 0;
     unsigned tid = 0;
 
-    while (data_stream.HasLines()) {
-        std::vector<std::string> row = data_stream.GetNextLine();
+    while (data_stream.HasNextRow()) {
+        std::vector<std::string> row = data_stream.GetNextRow();
         if (row.empty()) {
             continue;
         }

--- a/src/model/transactional_data.cpp
+++ b/src/model/transactional_data.cpp
@@ -19,9 +19,9 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFrom(IDatasetStream&
 }
 
 std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(
-    IDatasetStream& data_stream,
-    unsigned tid_col_index,
-    unsigned item_col_index) {
+        IDatasetStream& data_stream,
+        unsigned tid_col_index,
+        unsigned item_col_index) {
     std::vector<std::string> item_universe;
     std::unordered_map<std::string, unsigned> item_universe_set;
     std::unordered_map<unsigned, Itemset> transactions;
@@ -89,7 +89,8 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(IDataset
             }
             unsigned item_id = latest_item_id;
 
-            auto const [item_iter, was_inserted] = item_universe_set.try_emplace(item_name, item_id);
+            auto const [item_iter, was_inserted] = item_universe_set.try_emplace(item_name,
+                                                                                 item_id);
             if (was_inserted) {
                 // TODO(alexandrsmirn) попробовать избежать этого добавления.
                 item_universe.push_back(std::move(item_name));
@@ -112,4 +113,4 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromTabular(IDataset
                                                                     std::move(transactions)));
 }
 
-} // namespace model
+}  // namespace model

--- a/src/model/transactional_data.cpp
+++ b/src/model/transactional_data.cpp
@@ -27,8 +27,7 @@ std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(
     std::unordered_map<unsigned, Itemset> transactions;
     unsigned latest_item_id = 0;
 
-    assert(data_stream.GetNumberOfColumns() >
-           static_cast<int>(std::max(tid_col_index, item_col_index)));
+    assert(data_stream.GetNumberOfColumns() > std::max(tid_col_index, item_col_index));
 
     while (data_stream.HasNextRow()) {
         std::vector<std::string> row = data_stream.GetNextRow();

--- a/src/model/transactional_data.h
+++ b/src/model/transactional_data.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include "csv_parser.h"
+#include "idataset_stream.h"
 #include "itemset.h"
 #include "transactional_input_format.h"
 
@@ -15,11 +16,11 @@ private:
     std::vector<std::string> item_universe_;
     std::unordered_map<unsigned, Itemset> transactions_;
 
-    static std::unique_ptr<TransactionalData> CreateFromSingular(CSVParser& file_input,
+    static std::unique_ptr<TransactionalData> CreateFromSingular(IDatasetStream& file_input,
                                                                  unsigned tid_col_index = 0,
                                                                  unsigned item_col_index = 1);
 
-    static std::unique_ptr<TransactionalData> CreateFromTabular(CSVParser& file_input,
+    static std::unique_ptr<TransactionalData> CreateFromTabular(IDatasetStream& file_input,
                                                                 bool has_tid);
 
     TransactionalData(std::vector<std::string> item_universe,
@@ -43,7 +44,7 @@ public:
     size_t GetUniverseSize() const noexcept { return item_universe_.size(); }
     size_t GetNumTransactions() const noexcept { return transactions_.size(); }
 
-    static std::unique_ptr<TransactionalData> CreateFrom(CSVParser& file_input,
+    static std::unique_ptr<TransactionalData> CreateFrom(IDatasetStream& file_input,
                                                          InputFormat const& input_type);
 };
 

--- a/src/model/transactional_data.h
+++ b/src/model/transactional_data.h
@@ -16,11 +16,11 @@ private:
     std::vector<std::string> item_universe_;
     std::unordered_map<unsigned, Itemset> transactions_;
 
-    static std::unique_ptr<TransactionalData> CreateFromSingular(IDatasetStream& file_input,
+    static std::unique_ptr<TransactionalData> CreateFromSingular(IDatasetStream& data_stream,
                                                                  unsigned tid_col_index = 0,
                                                                  unsigned item_col_index = 1);
 
-    static std::unique_ptr<TransactionalData> CreateFromTabular(IDatasetStream& file_input,
+    static std::unique_ptr<TransactionalData> CreateFromTabular(IDatasetStream& data_stream,
                                                                 bool has_tid);
 
     TransactionalData(std::vector<std::string> item_universe,
@@ -44,7 +44,7 @@ public:
     size_t GetUniverseSize() const noexcept { return item_universe_.size(); }
     size_t GetNumTransactions() const noexcept { return transactions_.size(); }
 
-    static std::unique_ptr<TransactionalData> CreateFrom(IDatasetStream& file_input,
+    static std::unique_ptr<TransactionalData> CreateFrom(IDatasetStream& data_stream,
                                                          InputFormat const& input_type);
 };
 

--- a/src/parser/csv_parser.cpp
+++ b/src/parser/csv_parser.cpp
@@ -39,7 +39,7 @@ CSVParser::CSVParser(const std::filesystem::path& path, char separator, bool has
         PeekNext();
     }
 
-    std::vector<std::string> next_parsed = ParseNext();
+    std::vector<std::string> next_parsed = GetNextLine();
     number_of_columns_ = next_parsed.size();
     column_names_ = std::move(next_parsed);
 
@@ -103,7 +103,7 @@ std::string CSVParser::GetUnparsedLine(const unsigned long long line_index) {
     GetLine(line_index);
     std::string line = next_line_;
 
-    /* For correctness of ParseNext() after this method */
+    /* For correctness of GetNextLine() after this method */
     GetNextIfHas();
 
     return line;
@@ -127,7 +127,7 @@ std::vector<std::string> CSVParser::ParseLine(const unsigned long long line_inde
     return parsed;
 }
 
-std::vector<std::string> CSVParser::ParseNext() {
+std::vector<std::string> CSVParser::GetNextLine() {
     std::vector<std::string> result = ParseString(next_line_);
 
     GetNextIfHas();

--- a/src/parser/csv_parser.cpp
+++ b/src/parser/csv_parser.cpp
@@ -39,7 +39,7 @@ CSVParser::CSVParser(const std::filesystem::path& path, char separator, bool has
         PeekNext();
     }
 
-    std::vector<std::string> next_parsed = GetNextLine();
+    std::vector<std::string> next_parsed = GetNextRow();
     number_of_columns_ = next_parsed.size();
     column_names_ = std::move(next_parsed);
 
@@ -103,7 +103,7 @@ std::string CSVParser::GetUnparsedLine(const unsigned long long line_index) {
     GetLine(line_index);
     std::string line = next_line_;
 
-    /* For correctness of GetNextLine() after this method */
+    /* For correctness of GetNextRow() after this method */
     GetNextIfHas();
 
     return line;
@@ -127,7 +127,7 @@ std::vector<std::string> CSVParser::ParseLine(const unsigned long long line_inde
     return parsed;
 }
 
-std::vector<std::string> CSVParser::GetNextLine() {
+std::vector<std::string> CSVParser::GetNextRow() {
     std::vector<std::string> result = ParseString(next_line_);
 
     GetNextIfHas();

--- a/src/parser/csv_parser.h
+++ b/src/parser/csv_parser.h
@@ -11,7 +11,9 @@
 #include <string>
 #include <vector>
 
-class CSVParser {
+#include "idataset_stream.h"
+
+class CSVParser : public model::IDatasetStream {
 private:
     std::ifstream source_;
     char separator_;
@@ -37,17 +39,17 @@ public:
     explicit CSVParser(const std::filesystem::path& path);
     CSVParser(const std::filesystem::path& path, char separator, bool has_header);
 
-    std::vector<std::string> ParseNext();
+    std::vector<std::string> GetNextLine() override;
     std::string GetUnparsedLine(const unsigned long long line_index);
     std::vector<std::string> ParseLine(const unsigned long long line_index);
-    bool GetHasNext() const {
+    bool HasLines() const override {
         return has_next_;
     }
     char GetSeparator() const {
         return separator_;
     }
-    int GetNumberOfColumns() const { return number_of_columns_; }
-    std::string GetColumnName(int index) const { return column_names_[index]; }
-    std::string GetRelationName() const { return relation_name_; }
-    void Reset();
+    int GetNumberOfColumns() const override { return number_of_columns_; }
+    std::string GetColumnName(int index) const override { return column_names_[index]; }
+    std::string GetRelationName() const override { return relation_name_; }
+    void Reset() override;
 };

--- a/src/parser/csv_parser.h
+++ b/src/parser/csv_parser.h
@@ -39,10 +39,10 @@ public:
     explicit CSVParser(const std::filesystem::path& path);
     CSVParser(const std::filesystem::path& path, char separator, bool has_header);
 
-    std::vector<std::string> GetNextLine() override;
+    std::vector<std::string> GetNextRow() override;
     std::string GetUnparsedLine(const unsigned long long line_index);
     std::vector<std::string> ParseLine(const unsigned long long line_index);
-    bool HasLines() const override {
+    bool HasNextRow() const override {
         return has_next_;
     }
     char GetSeparator() const {

--- a/src/parser/csv_parser.h
+++ b/src/parser/csv_parser.h
@@ -48,7 +48,7 @@ public:
     char GetSeparator() const {
         return separator_;
     }
-    int GetNumberOfColumns() const override { return number_of_columns_; }
+    size_t GetNumberOfColumns() const override { return number_of_columns_; }
     std::string GetColumnName(int index) const override { return column_names_[index]; }
     std::string GetRelationName() const override { return relation_name_; }
     void Reset() override;

--- a/src/util/program_option_strings.h
+++ b/src/util/program_option_strings.h
@@ -6,31 +6,31 @@
 #pragma once
 
 namespace program_option_strings {
-constexpr auto Help = "help";
-constexpr auto Task = "task";
-constexpr auto Algorithm = "algorithm";
-constexpr auto Data = "data";
+constexpr auto kHelp = "help";
+constexpr auto kTask = "task";
+constexpr auto kAlgorithm = "algorithm";
+constexpr auto kData = "data";
 #define SEPARATOR "separator"
-constexpr auto SeparatorConfig = SEPARATOR;
-constexpr auto SeparatorLibArg = SEPARATOR ",s";
+constexpr auto kSeparatorConfig = SEPARATOR;
+constexpr auto kSeparatorLibArg = SEPARATOR ",s";
 #undef SEPARATOR
-constexpr auto HasHeader = "has_header";
-constexpr auto EqualNulls = "is_null_equal_null";
-constexpr auto Threads = "threads";
-constexpr auto Error = "error";
-constexpr auto MaximumLhs = "max_lhs";
-constexpr auto Seed = "seed";
-constexpr auto MinimumSupport = "minsup";
-constexpr auto MinimumConfidence = "minconf";
-constexpr auto InputFormat = "input_format";
-constexpr auto TIdColumnIndex = "tid_column_index";
-constexpr auto ItemColumnIndex = "item_column_index";
-constexpr auto FirstColumnTId = "has_tid";
-constexpr auto Metric = "metric";
-constexpr auto LhsIndices = "lhs_indices";
-constexpr auto RhsIndices = "rhs_indices";
-constexpr auto Parameter = "parameter";
-constexpr auto DistToNullIsInfinity = "dist_to_null_infinity";
-constexpr auto QGramLength = "q";
-constexpr auto MetricAlgorithm = "metric_algorithm";
+constexpr auto kHasHeader = "has_header";
+constexpr auto kEqualNulls = "is_null_equal_null";
+constexpr auto kThreads = "threads";
+constexpr auto kError = "error";
+constexpr auto kMaximumLhs = "max_lhs";
+constexpr auto kSeed = "seed";
+constexpr auto kMinimumSupport = "minsup";
+constexpr auto kMinimumConfidence = "minconf";
+constexpr auto kInputFormat = "input_format";
+constexpr auto kTIdColumnIndex = "tid_column_index";
+constexpr auto kItemColumnIndex = "item_column_index";
+constexpr auto kFirstColumnTId = "has_tid";
+constexpr auto kMetric = "metric";
+constexpr auto kLhsIndices = "lhs_indices";
+constexpr auto kRhsIndices = "rhs_indices";
+constexpr auto kParameter = "parameter";
+constexpr auto kDistToNullIsInfinity = "dist_to_null_infinity";
+constexpr auto kQGramLength = "q";
+constexpr auto kMetricAlgorithm = "metric_algorithm";
 }  // namespace program_option_strings

--- a/src/util/program_option_strings.h
+++ b/src/util/program_option_strings.h
@@ -33,4 +33,6 @@ constexpr auto kParameter = "parameter";
 constexpr auto kDistToNullIsInfinity = "dist_to_null_infinity";
 constexpr auto kQGramLength = "q";
 constexpr auto kMetricAlgorithm = "metric_algorithm";
+constexpr auto kRadius = "radius";
+constexpr auto kRatio = "ratio";
 }  // namespace program_option_strings

--- a/tests/test_algo_interfaces.cpp
+++ b/tests/test_algo_interfaces.cpp
@@ -35,7 +35,7 @@ static inline void GetKeysTestImpl(KeysTestParams const& p) {
     FDAlgorithm::Config c{.data = path,
                           .separator = p.sep,
                           .has_header = p.has_header,
-                          .special_params = {{posr::Seed, 0}, {posr::Error, 0.0}}};
+                          .special_params = {{posr::kSeed, 0}, {posr::kError, 0.0}}};
     algos::Pyro pyro(c);
 
     pyro.Execute();

--- a/tests/test_fd_mine.cpp
+++ b/tests/test_fd_mine.cpp
@@ -140,7 +140,7 @@ TEST_F(AlgorithmTest, FD_Mine_ReturnsSameAsPyro) {
             FDAlgorithm::Config c{.data = path / LightDatasets::DatasetName(i),
                                   .separator = LightDatasets::Separator(i),
                                   .has_header = LightDatasets::HasHeader(i),
-                                  .special_params = {{posr::Seed, 0}, {posr::Error, 0.0}}};
+                                  .special_params = {{posr::kSeed, 0}, {posr::kError, 0.0}}};
             auto pyro = algos::Pyro(c);
 
             algorithm->Execute();

--- a/tests/test_metric_verifier.cpp
+++ b/tests/test_metric_verifier.cpp
@@ -27,17 +27,17 @@ struct MetricVerifyingParams {
                           bool const dist_to_null_infinity = false,
                           bool const expected = true,
                           unsigned const q = 2)
-        : params({{posr::Parameter, min_parameter},
-                  {posr::LhsIndices, std::move(lhs_indices)},
-                  {posr::RhsIndices, std::move(rhs_indices)},
-                  {posr::Data, dataset},
-                  {posr::SeparatorConfig, separator},
-                  {posr::HasHeader, has_header},
-                  {posr::EqualNulls, true},
-                  {posr::Metric, metric},
-                  {posr::QGramLength, q},
-                  {posr::MetricAlgorithm, algo},
-                  {posr::DistToNullIsInfinity, dist_to_null_infinity}}),
+        : params({{posr::kParameter, min_parameter},
+                  {posr::kLhsIndices, std::move(lhs_indices)},
+                  {posr::kRhsIndices, std::move(rhs_indices)},
+                  {posr::kData, dataset},
+                  {posr::kSeparatorConfig, separator},
+                  {posr::kHasHeader, has_header},
+                  {posr::kEqualNulls, true},
+                  {posr::kMetric, metric},
+                  {posr::kQGramLength, q},
+                  {posr::kMetricAlgorithm, algo},
+                  {posr::kDistToNullIsInfinity, dist_to_null_infinity}}),
           expected(expected) {}
 };
 
@@ -64,7 +64,7 @@ TEST_P(TestMetricVerifying, DefaultTest) {
     }
     ASSERT_TRUE(GetResult(*verifier));
 
-    auto new_parameter = boost::any_cast<long double>(params.at(posr::Parameter));
+    auto new_parameter = boost::any_cast<long double>(params.at(posr::kParameter));
     new_parameter -= 1e-4;
     if (new_parameter < 0) return;
     verifier->SetParameter(new_parameter);

--- a/tests/test_typed_column_data.cpp
+++ b/tests/test_typed_column_data.cpp
@@ -32,9 +32,9 @@ class TestTypeParsing : public ::testing::TestWithParam<TypeParsingParams> {};
 static inline std::vector<mo::TypedColumnData> CreateColumnData(std::string_view data, char sep,
                                                                 bool has_header) {
     auto const path = fs::current_path() / "input_data" / data;
-    CSVParser input_generator(path, sep, has_header);
+    auto input_generator = std::make_unique<CSVParser>(path, sep, has_header);
     std::unique_ptr<model::ColumnLayoutTypedRelationData> relation_data =
-        model::ColumnLayoutTypedRelationData::CreateFrom(input_generator, true, -1, -1);
+        model::ColumnLayoutTypedRelationData::CreateFrom(*input_generator, true, -1, -1);
     std::vector<mo::TypedColumnData> col_data = std::move(relation_data->GetColumnData());
     return col_data;
 }

--- a/tests/test_typo_miner.cpp
+++ b/tests/test_typo_miner.cpp
@@ -18,14 +18,14 @@ struct TestingParam {
     TestingParam(std::string const& dataset,
                  char const separator, bool const has_header, bool const is_null_equal_null,
                  unsigned const max_lhs, double const error, ushort const threads)
-        : params({{posr::Data, dataset},
-                  {posr::SeparatorConfig, separator},
-                  {posr::HasHeader, has_header},
-                  {posr::EqualNulls, is_null_equal_null},
-                  {posr::MaximumLhs, max_lhs},
-                  {posr::Error, error},
-                  {posr::Threads, threads},
-                  {posr::Seed, 0}}) {}
+        : params({{posr::kData, dataset},
+                  {posr::kSeparatorConfig, separator},
+                  {posr::kHasHeader, has_header},
+                  {posr::kEqualNulls, is_null_equal_null},
+                  {posr::kMaximumLhs, max_lhs},
+                  {posr::kError, error},
+                  {posr::kThreads, threads},
+                  {posr::kSeed, 0}}) {}
 };
 
 /* FD represented as vector where all elements except last are lhs indices and

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -26,8 +26,8 @@ TEST(pliChecker, first) {
     auto path = fs::current_path().append("input_data").append("Test1.csv");
     deque<vector<int>> index;
     try {
-        CSVParser csv_parser(path);
-        auto test = ColumnLayoutRelationData::CreateFrom(csv_parser, true);
+        auto csv_parser = std::make_unique<CSVParser>(path);
+        auto test = ColumnLayoutRelationData::CreateFrom(*csv_parser, true);
         auto column_data = test->GetColumnData(0);
         index = column_data.GetPositionListIndex()->GetIndex();
     }
@@ -48,8 +48,8 @@ TEST(pliChecker, second) {
     deque<vector<int>> index;
     try {
         auto path = fs::current_path().append("input_data").append("Test1.csv");
-        CSVParser csv_parser(path);
-        auto test = ColumnLayoutRelationData::CreateFrom(csv_parser, false);
+        auto csv_parser = std::make_unique<CSVParser>(path);
+        auto test = ColumnLayoutRelationData::CreateFrom(*csv_parser, false);
         auto column_data = test->GetColumnData(0);
         index = column_data.GetPositionListIndex()->GetIndex();
     }
@@ -66,11 +66,11 @@ TEST(pliIntersectChecker, first) {
 
     try {
         auto path = fs::current_path().append("input_data");
-        CSVParser csv_parser_1(path / "ProbeTest1.csv");
-        CSVParser csv_parser_2(path / "ProbeTest2.csv");
+        auto csv_parser_1 = std::make_unique<CSVParser>(path / "ProbeTest1.csv");
+        auto csv_parser_2 = std::make_unique<CSVParser>(path / "ProbeTest2.csv");
 
-        auto test1 = ColumnLayoutRelationData::CreateFrom(csv_parser_1, false);
-        auto test2 = ColumnLayoutRelationData::CreateFrom(csv_parser_2, false);
+        auto test1 = ColumnLayoutRelationData::CreateFrom(*csv_parser_1, false);
+        auto test2 = ColumnLayoutRelationData::CreateFrom(*csv_parser_2, false);
         auto pli1 = test1->GetColumnData(0).GetPositionListIndex();
         auto pli2 = test2->GetColumnData(0).GetPositionListIndex();
 
@@ -106,8 +106,8 @@ TEST(IdentifierSetTest, Computation) {
 
     try {
         auto path = fs::current_path().append("input_data").append("BernoulliRelation.csv");
-        CSVParser parser(path);
-        auto relation = ColumnLayoutRelationData::CreateFrom(parser, false);
+        auto parser = std::make_unique<CSVParser>(path);
+        auto relation = ColumnLayoutRelationData::CreateFrom(*parser, false);
 
         for (unsigned i = 0; i < relation->GetNumRows(); ++i) {
             id_sets.insert(util::IdentifierSet(relation.get(), i).ToString());
@@ -142,8 +142,8 @@ TEST(IdentifierSetTest, Intersection) {
 
     try {
         auto path = fs::current_path().append("input_data").append("BernoulliRelation.csv");
-        CSVParser parser(path);
-        auto relation = ColumnLayoutRelationData::CreateFrom(parser, false);
+        auto parser = std::make_unique<CSVParser>(path);
+        auto relation = ColumnLayoutRelationData::CreateFrom(*parser, false);
         std::vector<util::IdentifierSet> id_sets;
 
         for (unsigned i = 0; i < relation->GetNumRows(); ++i) {
@@ -187,8 +187,8 @@ void TestAgreeSetFactory(AgreeSetFactory::Configuration c) {
 
     try {
         auto path = fs::current_path().append("input_data").append("BernoulliRelation.csv");
-        CSVParser parser(path);
-        auto relation = ColumnLayoutRelationData::CreateFrom(parser, false);
+        auto parser = std::make_unique<CSVParser>(path);
+        auto relation = ColumnLayoutRelationData::CreateFrom(*parser, false);
         AgreeSetFactory factory(relation.get(), c);
         for (util::AgreeSet const& agree_set : factory.GenAgreeSets()) {
             agree_sets_actual.insert(agree_set.ToString());

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -17,8 +17,8 @@ protected:
         namespace posr = program_option_strings;
 
         FDAlgorithm::Config c{ .data = path, .separator = separator, .has_header = has_header };
-        c.special_params[posr::Error] = 0.0;
-        c.special_params[posr::Seed] = 0;
+        c.special_params[posr::kError] = 0.0;
+        c.special_params[posr::kSeed] = 0;
         return std::make_unique<T>(c);
     }
 };


### PR DESCRIPTION
Part of the way towards implementing Python bindings. Make primitives use an abstract interface to read data instead of storing a (specific) parser.