### PR TITLE
Set libraries to build release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,11 @@ include_directories(
 # adding submodules
 add_subdirectory("lib/googletest")
 
+set( CMAKE_BUILD_TYPE_COPY "${CMAKE_BUILD_TYPE}" )
+set( CMAKE_BUILD_TYPE "Release" )
 option(build_static_lib "Build easyloggingpp as a static library" ON)
 add_subdirectory("lib/easyloggingpp")
+set( CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_COPY} )
 
 add_subdirectory("src")
 add_subdirectory("tests")


### PR DESCRIPTION
Some libraries, e.g. easylogging, fail to compile in debug mode as they do not pass compiler checks on certain compiler versions, producing warnings that are treated as errors. Furthermore, there is not much sense in debugging libraries by default.

Solution: temporarily set cmake build type to release when processing libraries.