### PR TITLE
Add github workflow for codestyle checking

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -22,7 +22,8 @@ jobs:
         formatterOutput=$(git diff origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | clang-format-diff-12 -p 1)
         
         if [ "$formatterOutput" != "clang-format did not modify any files" ] &&
-           [ "$formatterOutput" != "no modified files to format" ]
+           [ "$formatterOutput" != "no modified files to format" ] &&
+           [ "$formatterOutput" != "" ]
         then
           echo ":x: :x: :x:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`c++" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -37,25 +37,25 @@ jobs:
         sudo apt-get update
         sudo apt-get install gcc-10 g++-10 cmake build-essential
     - name: Cache Boost
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-boost
       with:
         path: ${{github.workspace}}/lib/boost
         key: ${{ runner.os }}-boost
     - name: Cache googletest
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-googletest
       with:
         path: ${{github.workspace}}/lib/googletest
         key: ${{ runner.os }}-googletest
     - name: Cache easyloggingpp
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-easyloggingpp
       with:
         path: ${{github.workspace}}/lib/easyloggingpp
         key: ${{ runner.os }}-easyloggingpp
     - name: Cache better-enums
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-better-enums
       with:
         path: ${{github.workspace}}/lib/better-enums

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -1,0 +1,49 @@
+name: clang-format
+on: [pull_request]
+jobs:
+  clang-format-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Pull clang-format
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format-12
+        
+    - name: Fetch branches
+      run: |
+        echo $GITHUB_BASE_REF
+        echo $GITHUB_HEAD_REF
+        git fetch origin $GITHUB_BASE_REF 
+        git fetch origin $GITHUB_HEAD_REF
+        
+    - name: Check formatting
+      run: |       
+        formatterOutput=$(git diff origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | clang-format-diff-12 -p 1)
+        
+        if [ "$formatterOutput" != "clang-format did not modify any files" ] &&
+           [ "$formatterOutput" != "no modified files to format" ]
+        then
+          echo ":x: :x: :x:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`c++" >> $GITHUB_STEP_SUMMARY
+          echo "$formatterOutput" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "$formatterOutput"
+          exit 1
+        fi
+        
+        echo "$formatterOutput"
+        echo "### $formatterOutput :heavy_check_mark:" >> $GITHUB_STEP_SUMMARY
+  clang-tidy-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # Optionally generate compile_commands.json
+
+    - uses: ZedThree/clang-tidy-review@v0.10.0
+      id: review
+    # If there are any comments, fail the check
+    - if: steps.review.outputs.total_comments > 0
+      run: exit 1

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -1,29 +1,21 @@
-name: codestyle-checks
+name: Codestyle
 on: [pull_request]
 jobs:
   clang-format-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Pull clang-format
       run: |
         sudo apt-get update
         sudo apt-get install -y clang-format-12
-        
-    - name: Fetch branches
-      run: |
-        echo $GITHUB_BASE_REF
-        echo $GITHUB_HEAD_REF
-        git fetch origin $GITHUB_BASE_REF 
-        git fetch origin $GITHUB_HEAD_REF
-        
     - name: Check formatting
       run: |       
-        formatterOutput=$(git diff origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | clang-format-diff-12 -p 1)
+        formatterOutput=$( git diff origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF | clang-format-diff-12 -p 1)
         
-        if [ "$formatterOutput" != "clang-format did not modify any files" ] &&
-           [ "$formatterOutput" != "no modified files to format" ] &&
-           [ "$formatterOutput" != "" ]
+        if [ "$formatterOutput" != "" ]
         then
           echo ":x: :x: :x:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`c++" >> $GITHUB_STEP_SUMMARY
@@ -35,16 +27,85 @@ jobs:
         
         echo "$formatterOutput"
         echo "### $formatterOutput :heavy_check_mark:" >> $GITHUB_STEP_SUMMARY
+  
   clang-tidy-check:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
+    - name: Install build tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-10 g++-10 cmake build-essential
+    - name: Cache Boost
+      uses: actions/cache@v2
+      id: cache-boost
+      with:
+        path: ${{github.workspace}}/lib/boost
+        key: ${{ runner.os }}-boost
+    - name: Cache googletest
+      uses: actions/cache@v2
+      id: cache-googletest
+      with:
+        path: ${{github.workspace}}/lib/googletest
+        key: ${{ runner.os }}-googletest
+    - name: Cache easyloggingpp
+      uses: actions/cache@v2
+      id: cache-easyloggingpp
+      with:
+        path: ${{github.workspace}}/lib/easyloggingpp
+        key: ${{ runner.os }}-easyloggingpp
+    - name: Cache better-enums
+      uses: actions/cache@v2
+      id: cache-better-enums
+      with:
+        path: ${{github.workspace}}/lib/better-enums
+        key: ${{ runner.os }}better-enums
 
-    # Optionally generate compile_commands.json
-
+    - name: Install Boost
+      run: |
+        wget -O boost_1_72_0.tar.gz https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.gz/download
+        tar xzvf boost_1_72_0.tar.gz
+        cd boost_1_72_0
+        ./bootstrap.sh --prefix=${{github.workspace}}/lib/boost
+        ./b2
+        sudo ./b2 install
+      if: steps.cache-boost.outputs.cache-hit != 'true'
+    - name: Download googletest
+      run: |
+        mkdir -p lib
+        sudo chown -R $USER lib
+        cd lib
+        git clone https://github.com/google/googletest/ --branch release-1.10.0
+      if: steps.cache-googletest.outputs.cache-hit != 'true'
+    - name: Download easyloggingpp
+      run: |
+        mkdir -p lib
+        sudo chown -R $USER lib
+        cd lib
+        git clone https://github.com/amrayn/easyloggingpp/ --branch v9.97.0
+      if: steps.cache-easyloggingpp.outputs.cache-hit != 'true'
+    - name: Download better-enums
+      run: |
+        mkdir -p lib
+        sudo chown -R $USER lib
+        cd lib
+        git clone https://github.com/aantron/better-enums.git --branch 0.11.3
+      if: steps.cache-better-enums.outputs.cache-hit != 'true'
+      
+    - name: Generate compile_commands.json
+      run: |
+        cmake -DCMAKE_C_COMPILER=gcc-10 \
+          -DCMAKE_CXX_COMPILER=g++-10 \
+          -DBOOST_ROOT=${{github.workspace}}/lib/boost \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -Dgtest_disable_pthreads=OFF \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          . -B ${{github.workspace}}/build
+                    
     - uses: ZedThree/clang-tidy-review@v0.10.0
       id: review
+      with:
+        build_dir: build
     # If there are any comments, fail the check
     - if: steps.review.outputs.total_comments > 0
-      run: exit 1
+      run: exit 1 

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -1,4 +1,4 @@
-name: clang-format
+name: codestyle-checks
 on: [pull_request]
 jobs:
   clang-format-check:


### PR DESCRIPTION
New workflow was created. It includes two jobs for clang-format and clang-tidy. 

Clang-format detects formatting issues. It creates a report in workflow's summary.
Clang-tidy finds typical programming errors and codestyle violations as well.  

Solves this issue: https://github.com/Mstrutov/Desbordante/issues/93
Also that would be nice to have a config file for clang-tidy: https://github.com/Mstrutov/Desbordante/issues/142
