### PR TITLE
Set continuation indent to 8, turn on case-label indentation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,6 @@ BasedOnStyle: Google
 AccessModifierOffset: -4
 TabWidth: 4
 IndentWidth: 4
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 8
 ColumnLimit: 100
-IndentCaseLabels: false
 AllowShortFunctionsOnASingleLine: Empty


### PR DESCRIPTION
Sets continuation indent width to 8 spaces (size of two tabs) to make it easier to distinguish wrapped function arguments from its body.
Before:
```cpp
void VeryVeryVeryVeryVeryLongFunctionName(
    argument1, argument2, argument3, argument4) {
    function body
}
```
After:
```cpp
void VeryVeryVeryVeryVeryLongFunctionName(
        argument1, argument2, argument3, argument4) {
    function body
}
```
Also turns on case-label indentation because now last case block looks weird if it has braces: case block closing brace has the same indentation level as entire switch block closing brace which is hard to read.
Before:
```cpp
    switch (config_.as_gen_method) {
    /* Another case blocks */
    case AgreeSetsGenMethod::kUsingGetAgreeSet: {
        method_str = "`kUsingGetAgreeSet`";
        agree_sets = GenAsUsingGetAgreeSets();
        break;
    }
    }
```
After:
```cpp
    switch (config_.as_gen_method) {
        /* Another case blocks */
        case AgreeSetsGenMethod::kUsingGetAgreeSet: {
            method_str = "`kUsingGetAgreeSet`";
            agree_sets = GenAsUsingGetAgreeSets();
            break;
        }
    }
```