### PR TITLE
Implement `StringType::Clone` to fix incorrect string cloning

### DIFF
--- a/src/model/types/string_type.h
+++ b/src/model/types/string_type.h
@@ -20,6 +20,10 @@ public:
         return GetValue<String>(value);
     }
 
+    [[nodiscard]] std::byte* Clone(std::byte const* value) const override {
+        return MakeValue(ValueToString(value));
+    }
+
     [[nodiscard]] CompareResult Compare(std::byte const* l, std::byte const* r) const override {
         auto const& l_val = GetValue<String>(l);
         auto const& r_val = GetValue<String>(r);


### PR DESCRIPTION
Base `Type::Clone` method is incorrect for `StringType` values because strings are represented as `std::string` objects. So to clone one we cannot just copy its byte representation, we should use `std::string` copy constructor instead. Fixes a bug discovered in #120, so this pr should be merged before statistics.