### PR TITLE
Remove git-lfs from tests workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,20 +42,31 @@ jobs:
       with:
         path: ${{github.workspace}}/lib/better-enums
         key: ${{ runner.os }}better-enums
-    - name: Install git-lfs
-      run: |
-        curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
-        git lfs install
-    - name: Generate lfs file list
-      run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-    - name: Restore lfs cache
+#     Uncomment this if we set up our own git lfs server
+#
+#     - name: Install git-lfs
+#       run: |
+#         curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+#         git lfs install
+#     - name: Generate lfs file list
+#       run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+#     - name: Restore lfs cache
+#       uses: actions/cache@v2
+#       id: lfs-cache
+#       with:
+#         path: .git/lfs
+#         key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+
+#     Also change this if we set up our own git lfs server
+    - name: Cache datasets
       uses: actions/cache@v2
-      id: lfs-cache
+      id: cache-datasets
       with:
-        path: .git/lfs
-        key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}-v1
+        path: ${{github.workspace}}/datasets
+        key: ${{ runner.os }}datasets
     - name: Pull datasets
       run: bash pull_datasets.sh
+      if: steps.cache-datasets.outputs.cache-hit != 'true'
     - name: Install Boost
       run: |
         wget -O boost_1_72_0.tar.gz https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.gz/download


### PR DESCRIPTION
Disable git lfs in CI workflow since right now every CI workflow run tries to pull datasets using git lfs thereby exhausting github lfs quota which leads to the problems with `clone/push/pull` operations. The `pull_datasets.sh` script should work just fine. Later we may get a greater quota or use our own lfs server and then undone those changes.