### PR TITLE
Update actions/cache version in cmake workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,25 +19,25 @@ jobs:
         sudo apt-get update
         sudo apt-get install gcc-10 g++-10 cmake build-essential
     - name: Cache Boost
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-boost
       with:
         path: ${{github.workspace}}/lib/boost
         key: ${{ runner.os }}-boost
     - name: Cache googletest
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-googletest
       with:
         path: ${{github.workspace}}/lib/googletest
         key: ${{ runner.os }}-googletest
     - name: Cache easyloggingpp
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-easyloggingpp
       with:
         path: ${{github.workspace}}/lib/easyloggingpp
         key: ${{ runner.os }}-easyloggingpp
     - name: Cache better-enums
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-better-enums
       with:
         path: ${{github.workspace}}/lib/better-enums
@@ -51,7 +51,7 @@ jobs:
 #     - name: Generate lfs file list
 #       run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 #     - name: Restore lfs cache
-#       uses: actions/cache@v2
+#       uses: actions/cache@v3
 #       id: lfs-cache
 #       with:
 #         path: .git/lfs
@@ -59,7 +59,7 @@ jobs:
 
 #     Also change this if we set up our own git lfs server
     - name: Cache datasets
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-datasets
       with:
         path: ${{github.workspace}}/datasets


### PR DESCRIPTION
V2 of actions/cache is outdated we should use V3 instead. V2 generates a lot of warnings about the deprecation of some features provided by the API's it uses.