### PR TITLE
Fix clang tidy workflow for forks

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -106,6 +106,11 @@ jobs:
       id: review
       with:
         build_dir: build
-    # If there are any comments, fail the check
-    - if: steps.review.outputs.total_comments > 0
-      run: exit 1 
+        split_workflow: true
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: clang-tidy-review
+        path: |
+          clang-tidy-review-output.json
+          clang-tidy-review-metadata.json

--- a/.github/workflows/post-review.yml
+++ b/.github/workflows/post-review.yml
@@ -1,0 +1,43 @@
+name: Post clang-tidy review comments
+
+on:
+  workflow_run:
+    workflows: ["Codestyle"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Downloads the artifact uploaded by the lint action
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-review"
+            })[0];
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/clang-tidy-review.zip', Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip clang-tidy-review.zip
+
+      - uses: ZedThree/clang-tidy-review/post@v0.10.0
+        id: post
+
+      # If there are any comments, fail the check
+      - if: steps.post.outputs.total_comments > 0
+        run: exit 1


### PR DESCRIPTION
Split clang tidy workflow to deal with security concerns.