### PR TITLE
Refactor config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ include_directories(
     "src/algorithms/association_rules"
     "src/algorithms/depminer"
     "src/algorithms/statistics"
+    "src/algorithms/options"
     "src/model"
     "src/model/types"
     "src/util"

--- a/src/algorithms/ac_algorithm.cpp
+++ b/src/algorithms/ac_algorithm.cpp
@@ -216,7 +216,7 @@ ACAlgorithm::Binop ACAlgorithm::InitializeBinop(char bin_operation) {
     return static_cast<Binop>(bin_operation);
 }
 
-unsigned long long ACAlgorithm::Execute() {
+unsigned long long ACAlgorithm::ExecuteInternal() {
     std::vector<model::TypedColumnData> const& data = typed_relation_->GetColumnData();
     if (data.empty()) {
         throw std::runtime_error("Empty table was given.");

--- a/src/algorithms/ac_algorithm.h
+++ b/src/algorithms/ac_algorithm.h
@@ -4,14 +4,15 @@
 #include <unordered_map>
 #include <vector>
 
-#include "ac.h"
-#include "column_layout_typed_relation_data.h"
-#include "primitive.h"
+#include "algorithms/legacy_primitive.h"
+#include "algorithms/primitive.h"
+#include "model/ac.h"
+#include "model/column_layout_typed_relation_data.h"
 #include "types.h"
 
 namespace algos {
 
-class ACAlgorithm : public algos::Primitive {
+class ACAlgorithm : public LegacyPrimitive {
 public:
     enum class Binop : char { Plus = '+', Minus = '-', Multiplication = '*', Division = '/' };
     enum class PairingRule { Trivial };
@@ -81,7 +82,7 @@ public:
     };
 
     explicit ACAlgorithm(Config const& config, bool test_mode = false)
-        : Primitive(config.data, config.separator, config.has_header,
+        : LegacyPrimitive(config.data, config.separator, config.has_header,
                     std::vector<std::string_view>()),
           typed_relation_(TypedRelation::CreateFrom(*input_generator_, true)),
           fuzziness_(config.fuzziness),
@@ -91,7 +92,7 @@ public:
           iterations_limit(config.iterations_limit),
           pairing_rule_(config.pairing_rule),
           test_mode_(test_mode) {
-        
+
         bin_operation_ = InitializeBinop(config.bin_operation);
     }
 
@@ -101,7 +102,7 @@ public:
     }
     RangesCollection const& GetRangesByColumns(size_t lhs_i, size_t rhs_i) const;
     void PrintRanges(std::vector<model::TypedColumnData> const& data) const;
-    unsigned long long Execute() override;
+    unsigned long long ExecuteInternal() override;
 };
 
 }  // namespace algos

--- a/src/algorithms/aidfd/aid.h
+++ b/src/algorithms/aidfd/aid.h
@@ -6,11 +6,11 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-#include "column.h"
-#include "fd_algorithm.h"
-#include "relational_schema.h"
-#include "search_tree.h"
-#include "vertical.h"
+#include "algorithms/aidfd/search_tree.h"
+#include "algorithms/fd_algorithm.h"
+#include "model/column.h"
+#include "model/relational_schema.h"
+#include "model/vertical.h"
 
 namespace algos {
 
@@ -38,8 +38,8 @@ private:
 
     boost::dynamic_bitset<> constant_columns_;
 
-    void Initialize() override;
-    unsigned long long ExecuteInternal() override;
+    void FitFd(model::IDatasetStream &data_stream) final;
+    unsigned long long ExecuteInternal() final;
 
     void BuildClusters();
     void CreateNegativeCover();
@@ -61,10 +61,8 @@ private:
 
     boost::dynamic_bitset<> BuildAgreeSet(size_t t1, size_t t2);
 
-    void LoadData();
-
 public:
-    explicit Aid(Config const& config);
+    Aid();
 };
 
 }  // namespace algos

--- a/src/algorithms/algo_factory.h
+++ b/src/algorithms/algo_factory.h
@@ -120,7 +120,7 @@ FDAlgorithm::Config CreateFDAlgorithmConfigFromMap(ParamsMap params) {
 
     c.data = std::filesystem::current_path() / "input_data" /
              ExtractParamFromMap<std::string>(params, onam::kData);
-    c.separator = ExtractParamFromMap<char>(params, onam::kSeparatorConfig);
+    c.separator = ExtractParamFromMap<char>(params, onam::kSeparator);
     c.has_header = ExtractParamFromMap<bool>(params, onam::kHasHeader);
     c.is_null_equal_null = ExtractParamFromMap<bool>(params, onam::kEqualNulls);
     c.max_lhs = ExtractParamFromMap<unsigned int>(params, onam::kMaximumLhs);
@@ -148,7 +148,7 @@ ARAlgorithm::Config CreateArAlgorithmConfigFromMap(ParamsMap params) {
 
     c.data = std::filesystem::current_path() / "input_data" /
              ExtractParamFromMap<std::string>(params, onam::kData);
-    c.separator = ExtractParamFromMap<char>(params, onam::kSeparatorConfig);
+    c.separator = ExtractParamFromMap<char>(params, onam::kSeparator);
     c.has_header = ExtractParamFromMap<bool>(params, onam::kHasHeader);
     c.minsup = ExtractParamFromMap<double>(params, onam::kMinimumSupport);
     c.minconf = ExtractParamFromMap<double>(params, onam::kMinimumConfidence);
@@ -186,7 +186,7 @@ MetricVerifier::Config CreateMetricVerifierConfigFromMap(ParamsMap params) {
     }
     c.data = std::filesystem::current_path() / "input_data" /
         ExtractParamFromMap<std::string>(params, onam::kData);
-    c.separator = ExtractParamFromMap<char>(params, onam::kSeparatorConfig);
+    c.separator = ExtractParamFromMap<char>(params, onam::kSeparator);
     c.has_header = ExtractParamFromMap<bool>(params, onam::kHasHeader);
     c.is_null_equal_null = ExtractParamFromMap<bool>(params, onam::kEqualNulls);
     c.lhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, onam::kLhsIndices);

--- a/src/algorithms/algo_factory.h
+++ b/src/algorithms/algo_factory.h
@@ -99,6 +99,13 @@ void LoadPrimitive(Primitive& prim, OptionMap&& options) {
     ConfigureFromMap(prim, options);
 }
 
+template <typename T, typename OptionMap>
+std::unique_ptr<T> CreateAndLoadPrimitive(OptionMap&& options) {
+    std::unique_ptr<T> prim = std::make_unique<T>();
+    LoadPrimitive(*prim, std::forward<OptionMap>(options));
+    return prim;
+}
+
 template <typename OptionMap>
 std::unique_ptr<Primitive> CreatePrimitive(PrimitiveType primitive_enum, OptionMap&& options) {
     std::unique_ptr<Primitive> primitive = CreatePrimitiveInstance(primitive_enum);

--- a/src/algorithms/algo_factory.h
+++ b/src/algorithms/algo_factory.h
@@ -69,7 +69,7 @@ using ArAlgorithmTuplesType = std::tuple<Apriori>;
 
 namespace details {
 
-namespace posr = program_option_strings;
+namespace onam = algos::config::names;
 
 template <typename AlgorithmBase = Primitive, typename AlgorithmsToSelect = AlgorithmTypesTuple,
           typename EnumType, typename... Args>
@@ -119,12 +119,12 @@ FDAlgorithm::Config CreateFDAlgorithmConfigFromMap(ParamsMap params) {
     FDAlgorithm::Config c;
 
     c.data = std::filesystem::current_path() / "input_data" /
-             ExtractParamFromMap<std::string>(params, posr::kData);
-    c.separator = ExtractParamFromMap<char>(params, posr::kSeparatorConfig);
-    c.has_header = ExtractParamFromMap<bool>(params, posr::kHasHeader);
-    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::kEqualNulls);
-    c.max_lhs = ExtractParamFromMap<unsigned int>(params, posr::kMaximumLhs);
-    c.parallelism = ExtractParamFromMap<ushort>(params, posr::kThreads);
+             ExtractParamFromMap<std::string>(params, onam::kData);
+    c.separator = ExtractParamFromMap<char>(params, onam::kSeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, onam::kHasHeader);
+    c.is_null_equal_null = ExtractParamFromMap<bool>(params, onam::kEqualNulls);
+    c.max_lhs = ExtractParamFromMap<unsigned int>(params, onam::kMaximumLhs);
+    c.parallelism = ExtractParamFromMap<ushort>(params, onam::kThreads);
 
     /* Is it correct to insert all specified parameters into the algorithm config, and not just the
      * necessary ones? It is definitely simpler, so for now leaving it like this
@@ -147,21 +147,21 @@ ARAlgorithm::Config CreateArAlgorithmConfigFromMap(ParamsMap params) {
     ARAlgorithm::Config c;
 
     c.data = std::filesystem::current_path() / "input_data" /
-             ExtractParamFromMap<std::string>(params, posr::kData);
-    c.separator = ExtractParamFromMap<char>(params, posr::kSeparatorConfig);
-    c.has_header = ExtractParamFromMap<bool>(params, posr::kHasHeader);
-    c.minsup = ExtractParamFromMap<double>(params, posr::kMinimumSupport);
-    c.minconf = ExtractParamFromMap<double>(params, posr::kMinimumConfidence);
+             ExtractParamFromMap<std::string>(params, onam::kData);
+    c.separator = ExtractParamFromMap<char>(params, onam::kSeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, onam::kHasHeader);
+    c.minsup = ExtractParamFromMap<double>(params, onam::kMinimumSupport);
+    c.minconf = ExtractParamFromMap<double>(params, onam::kMinimumConfidence);
 
     std::shared_ptr<model::InputFormat> input_format;
-    auto const input_format_arg = ExtractParamFromMap<std::string>(params, posr::kInputFormat);
+    auto const input_format_arg = ExtractParamFromMap<std::string>(params, onam::kInputFormat);
     if (input_format_arg == "singular") {
-        unsigned const tid_column_index = ExtractParamFromMap<unsigned>(params, posr::kTIdColumnIndex);
+        unsigned const tid_column_index = ExtractParamFromMap<unsigned>(params, onam::kTIdColumnIndex);
         unsigned const item_column_index =
-            ExtractParamFromMap<unsigned>(params, posr::kItemColumnIndex);
+            ExtractParamFromMap<unsigned>(params, onam::kItemColumnIndex);
         input_format = std::make_shared<model::Singular>(tid_column_index, item_column_index);
     } else if (input_format_arg == "tabular") {
-        bool const has_header = ExtractParamFromMap<bool>(params, posr::kFirstColumnTId);
+        bool const has_header = ExtractParamFromMap<bool>(params, onam::kFirstColumnTId);
         input_format = std::make_shared<model::Tabular>(has_header);
     } else {
         throw std::invalid_argument("\"" + input_format_arg + "\"" +
@@ -176,34 +176,34 @@ template <typename ParamsMap>
 MetricVerifier::Config CreateMetricVerifierConfigFromMap(ParamsMap params) {
     MetricVerifier::Config c;
 
-    c.parameter = ExtractParamFromMap<long double>(params, posr::kParameter);
+    c.parameter = ExtractParamFromMap<long double>(params, onam::kParameter);
     if (c.parameter < 0) {
         throw std::invalid_argument("Parameter should not be less than zero.");
     }
-    c.q = ExtractParamFromMap<unsigned>(params, posr::kQGramLength);
+    c.q = ExtractParamFromMap<unsigned>(params, onam::kQGramLength);
     if (c.q <= 0) {
         throw std::invalid_argument("Q-gram length should be greater than zero.");
     }
     c.data = std::filesystem::current_path() / "input_data" /
-        ExtractParamFromMap<std::string>(params, posr::kData);
-    c.separator = ExtractParamFromMap<char>(params, posr::kSeparatorConfig);
-    c.has_header = ExtractParamFromMap<bool>(params, posr::kHasHeader);
-    c.is_null_equal_null = ExtractParamFromMap<bool>(params, posr::kEqualNulls);
-    c.lhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, posr::kLhsIndices);
-    c.rhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, posr::kRhsIndices);
+        ExtractParamFromMap<std::string>(params, onam::kData);
+    c.separator = ExtractParamFromMap<char>(params, onam::kSeparatorConfig);
+    c.has_header = ExtractParamFromMap<bool>(params, onam::kHasHeader);
+    c.is_null_equal_null = ExtractParamFromMap<bool>(params, onam::kEqualNulls);
+    c.lhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, onam::kLhsIndices);
+    c.rhs_indices = ExtractParamFromMap<std::vector<unsigned int>>(params, onam::kRhsIndices);
     
-    c.metric = ExtractParamFromMap<std::string>(params, posr::kMetric);
+    c.metric = ExtractParamFromMap<std::string>(params, onam::kMetric);
     if (c.rhs_indices.size() > 1 && c.metric != "euclidean") {
         throw std::invalid_argument(
             "More than one RHS columns are only allowed for \"euclidean\" metric.");
     }
     if (c.metric != "euclidean" || c.rhs_indices.size() != 1) {
-        c.algo = ExtractParamFromMap<std::string>(params, posr::kMetricAlgorithm);
+        c.algo = ExtractParamFromMap<std::string>(params, onam::kMetricAlgorithm);
     }
     if (c.rhs_indices.size() != 2 && c.algo == "calipers") {
         throw std::invalid_argument("\"calipers\" algo is only available for 2 dimensions.");
     }
-    c.dist_to_null_infinity = ExtractParamFromMap<bool>(params, posr::kDistToNullIsInfinity);
+    c.dist_to_null_infinity = ExtractParamFromMap<bool>(params, onam::kDistToNullIsInfinity);
     return c;
 }
 

--- a/src/algorithms/algo_factory.h
+++ b/src/algorithms/algo_factory.h
@@ -5,9 +5,9 @@
 #include <boost/mp11/algorithm.hpp>
 #include <enum.h>
 
-#include "algorithms.h"
-#include "typo_miner.h"
-#include "program_option_strings.h"
+#include "algorithms/algorithms.h"
+#include "algorithms/options/names.h"
+#include "algorithms/typo_miner.h"
 
 namespace algos {
 

--- a/src/algorithms/algo_factory.h
+++ b/src/algorithms/algo_factory.h
@@ -107,10 +107,24 @@ std::unique_ptr<Primitive> CreatePrimitive(PrimitiveType primitive_enum, OptionM
 }
 
 template <typename OptionMap>
+std::unique_ptr<Primitive> CreateTypoMiner(OptionMap&& options) {
+    PrimitiveType precise_algo = details::ExtractOptionValue<PrimitiveType>(
+            options, config::names::kPreciseAlgorithm);
+    PrimitiveType approx_algo = details::ExtractOptionValue<PrimitiveType>(
+            options, config::names::kApproximateAlgorithm);
+    std::unique_ptr<TypoMiner> typo_miner = std::make_unique<TypoMiner>(precise_algo, approx_algo);
+    LoadPrimitive(*typo_miner, std::forward<OptionMap>(options));
+    return typo_miner;
+}
+
+template <typename OptionMap>
 std::unique_ptr<Primitive> CreatePrimitive(std::string const& primitive_name,
                                            OptionMap&& options) {
     if (primitive_name == "ac") {
         return details::CreateAcAlgorithmInstance(std::forward<OptionMap>(options));
+    }
+    if (primitive_name == "typo_miner") {
+        return CreateTypoMiner(std::forward<OptionMap>(options));
     }
     PrimitiveType const primitive_enum = PrimitiveType::_from_string(primitive_name.c_str());
     return CreatePrimitive(primitive_enum, std::forward<OptionMap>(options));

--- a/src/algorithms/algorithms.h
+++ b/src/algorithms/algorithms.h
@@ -18,6 +18,3 @@
 
 /* Metric FD verifier */
 #include "algorithms/metric_verifier.h"
-
-/* Algebraic constraints mining algorithm */
-#include "algorithms/ac_algorithm.h"

--- a/src/algorithms/ar_algorithm_enums.h
+++ b/src/algorithms/ar_algorithm_enums.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <enum.h>
+
+namespace algos {
+
+BETTER_ENUM(InputFormat, char,
+    singular = 0,
+    tabular
+);
+
+}  // namespace algos

--- a/src/algorithms/association_rules/apriori.cpp
+++ b/src/algorithms/association_rules/apriori.cpp
@@ -1,11 +1,13 @@
-#include "apriori.h"
+#include "algorithms/association_rules/apriori.h"
 
 #include <algorithm>
 #include <cassert>
 
-#include "easylogging++.h"
+#include <easylogging++.h>
 
 namespace algos {
+
+Apriori::Apriori() : ARAlgorithm({}) {}
 
 void Apriori::GenerateCandidates(std::vector<Node>& children) {
     auto const last_child_iter = std::prev(children.end());

--- a/src/algorithms/association_rules/apriori.h
+++ b/src/algorithms/association_rules/apriori.h
@@ -5,10 +5,10 @@
 #include <stack>
 #include <vector>
 
-#include "ar_algorithm.h"
-#include "candidate_hash_tree.h"
-#include "itemset.h"
-#include "node.h"
+#include "algorithms/ar_algorithm.h"
+#include "algorithms/association_rules/candidate_hash_tree.h"
+#include "algorithms/association_rules/node.h"
+#include "model/itemset.h"
 
 namespace algos {
 
@@ -37,8 +37,7 @@ private:
     unsigned long long FindFrequent() override;
 
 public:
-    explicit Apriori(Config const& config)
-        : ARAlgorithm(config, {}) {}
+    Apriori();
 
     std::list<std::set<std::string>> GetFrequentList() const override;
 };

--- a/src/algorithms/create_primitive.h
+++ b/src/algorithms/create_primitive.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <boost/mp11.hpp>
+#include <enum.h>
+
+#include "algorithms/algorithms.h"
+
+namespace algos {
+
+using PrimitiveTypes = std::tuple<Depminer, DFD, FastFDs, FDep, Fd_mine, Pyro, Tane, FUN,
+        hyfd::HyFD, Aid, Apriori, MetricVerifier, CsvStats>;
+
+/* Enumeration of all supported non-pipeline primitives. If you implement a new
+ * primitive please add its corresponding value to this enum and to the type
+ * tuple above.
+ * NOTE: algorithm string name representation is taken from the value in this
+ * enum, so name it appropriately (lowercase and without additional symbols).
+ */
+BETTER_ENUM(PrimitiveType, char,
+/* Functional dependency mining algorithms */
+    depminer = 0,
+    dfd,
+    fastfds,
+    fdep,
+    fdmine,
+    pyro,
+    tane,
+    fun,
+    hyfd,
+    aidfd,
+
+/* Association rules mining algorithms */
+    apriori,
+
+/* Metric verifier algorithm */
+    metric,
+
+/* Statistic algorithms */
+    stats
+)
+
+template <typename PrimitiveBase = Primitive>
+std::unique_ptr<PrimitiveBase> CreatePrimitiveInstance(PrimitiveType primitive) {
+    auto const create = [](auto I) -> std::unique_ptr<PrimitiveBase> {
+        using PrimitiveType = std::tuple_element_t<I, PrimitiveTypes>;
+        if constexpr (std::is_convertible_v<PrimitiveType *, PrimitiveBase *>) {
+            return std::make_unique<PrimitiveType>();
+        }
+        else {
+            throw std::invalid_argument("Cannot use "
+                                        + boost::typeindex::type_id<PrimitiveType>().pretty_name()
+                                        + " as "
+                                        + boost::typeindex::type_id<PrimitiveBase>().pretty_name());
+        }
+    };
+
+    return boost::mp11::mp_with_index<std::tuple_size<PrimitiveTypes>>(
+            static_cast<size_t>(primitive), create);
+}
+
+template <typename PrimitiveBase>
+std::vector<PrimitiveType> GetAllDerived() {
+    auto const is_derived = [](auto I) -> bool {
+        using PrimitiveType = std::tuple_element_t<I, PrimitiveTypes>;
+        return std::is_base_of_v<PrimitiveBase, PrimitiveType>;
+    };
+    std::vector<PrimitiveType> derived_from_base{};
+    for (PrimitiveType prim : PrimitiveType::_values()) {
+        if (boost::mp11::mp_with_index<std::tuple_size<PrimitiveTypes>>(static_cast<size_t>(prim),
+                                                                        is_derived)) {
+            derived_from_base.push_back(prim);
+        }
+    }
+    return derived_from_base;
+}
+
+}  // namespace algos

--- a/src/algorithms/depminer/depminer.cpp
+++ b/src/algorithms/depminer/depminer.cpp
@@ -1,4 +1,4 @@
-#include "depminer.h"
+#include "algorithms/depminer/depminer.h"
 
 #include <chrono>
 #include <list>
@@ -6,19 +6,21 @@
 
 #include <easylogging++.h>
 
-#include "column_combination.h"
-#include "column_data.h"
-#include "column_layout_relation_data.h"
-#include "relational_schema.h"
-#include "agree_set_factory.h"
+#include "model/column_combination.h"
+#include "model/relational_schema.h"
+#include "util/agree_set_factory.h"
 
 namespace algos {
 
-using boost::dynamic_bitset, std::make_shared, std::shared_ptr, std::setw, std::vector, std::list, std::dynamic_pointer_cast;
+Depminer::Depminer() : PliBasedFDAlgorithm(
+        {"AgreeSets generation", "Finding CMAXSets", "Finding LHS"}) {}
+
+using boost::dynamic_bitset, std::make_shared, std::shared_ptr, std::setw, std::vector, std::list,
+        std::dynamic_pointer_cast;
 
 unsigned long long Depminer::ExecuteInternal() {
-
     const auto start_time = std::chrono::system_clock::now();
+
     schema_ = relation_->GetSchema();
 
     progress_step_ = kTotalProgressPercent / schema_->GetNumColumns();

--- a/src/algorithms/depminer/depminer.h
+++ b/src/algorithms/depminer/depminer.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "fd_algorithm.h"
-#include "pli_based_fd_algorithm.h"
-#include "depminer/cmax_set.h"
+#include "algorithms/depminer/cmax_set.h"
+#include "algorithms/pli_based_fd_algorithm.h"
 
 namespace algos {
 
@@ -18,18 +17,11 @@ private:
     std::vector<CMAXSet> GenerateCmaxSets(std::unordered_set<Vertical> const& agree_sets);
 
     double progress_step_ = 0;
+    RelationalSchema const* schema_ = nullptr;
+    unsigned long long ExecuteInternal() final;
 
 public:
-    explicit Depminer(Config const& config)
-        : PliBasedFDAlgorithm(config, {"AgreeSets generation", "Finding CMAXSets", "Finding LHS"}) {
-    }
-    explicit Depminer(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config)
-        : PliBasedFDAlgorithm(std::move(relation), config,
-                              {"AgreeSets generation", "Finding CMAXSets", "Finding LHS"}) {}
-
-    unsigned long long ExecuteInternal() override;
-
-    const RelationalSchema* schema_ = nullptr;
+    Depminer();
 };
 
 }  // namespace algos

--- a/src/algorithms/dfd/dfd.cpp
+++ b/src/algorithms/dfd/dfd.cpp
@@ -1,14 +1,26 @@
-#include "dfd.h"
+#include "algorithms/dfd/dfd.h"
 
 #include <boost/asio.hpp>
 #include <easylogging++.h>
 
-#include "column_layout_relation_data.h"
-#include "relational_schema.h"
-#include "position_list_index.h"
-#include "lattice_traversal/lattice_traversal.h"
+#include "algorithms/dfd/lattice_traversal/lattice_traversal.h"
+#include "model/column_layout_relation_data.h"
+#include "model/relational_schema.h"
+#include "util/position_list_index.h"
 
 namespace algos {
+
+DFD::DFD() : PliBasedFDAlgorithm({kDefaultPhaseName}) {
+    RegisterOptions();
+}
+
+void DFD::RegisterOptions() {
+    RegisterOption(config::ThreadNumberOpt.GetOption(&number_of_threads_));
+}
+
+void DFD::MakeExecuteOptsAvailable() {
+    MakeOptionsAvailable(config::GetOptionNames(config::ThreadNumberOpt));
+}
 
 unsigned long long DFD::ExecuteInternal() {
     partition_storage_ = std::make_unique<PartitionStorage>(relation_.get(),
@@ -72,12 +84,5 @@ unsigned long long DFD::ExecuteInternal() {
 
     return apriori_millis;
 }
-
-DFD::DFD(Config const& config)
-    : PliBasedFDAlgorithm(config, {kDefaultPhaseName}), number_of_threads_(config_.parallelism) {}
-
-DFD::DFD(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config)
-    : PliBasedFDAlgorithm(std::move(relation), config, {kDefaultPhaseName}),
-      number_of_threads_(config_.parallelism) {}
 
 }  // namespace algos

--- a/src/algorithms/dfd/dfd.h
+++ b/src/algorithms/dfd/dfd.h
@@ -3,9 +3,10 @@
 #include <random>
 #include <stack>
 
-#include "pli_based_fd_algorithm.h"
-#include "vertical.h"
-#include "dfd/partition_storage/partition_storage.h"
+#include "algorithms/dfd/partition_storage/partition_storage.h"
+#include "algorithms/options/thread_number_opt.h"
+#include "algorithms/pli_based_fd_algorithm.h"
+#include "model/vertical.h"
 
 namespace algos {
 
@@ -14,13 +15,14 @@ private:
     std::unique_ptr<PartitionStorage> partition_storage_;
     std::vector<Vertical> unique_columns_;
 
-    unsigned int number_of_threads_;
+    config::ThreadNumType number_of_threads_;
 
-    unsigned long long ExecuteInternal() override;
+    void MakeExecuteOptsAvailable() final;
+    void RegisterOptions();
+    unsigned long long ExecuteInternal() final;
 
 public:
-    explicit DFD(Config const& config);
-    explicit DFD(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config);
+    DFD();
 };
 
 }  // namespace algos

--- a/src/algorithms/fastfds.cpp
+++ b/src/algorithms/fastfds.cpp
@@ -1,4 +1,4 @@
-#include "fastfds.h"
+#include "algorithms/fastfds.h"
 
 #include <easylogging++.h>
 
@@ -10,23 +10,25 @@
 #include <mutex>
 #include <thread>
 
-#include "agree_set_factory.h"
-#include "parallel_for.h"
+#include "util/agree_set_factory.h"
+#include "util/parallel_for.h"
 
 namespace algos {
 
 using std::vector, std::set;
 
-FastFDs::FastFDs(Config const& config)
-    : PliBasedFDAlgorithm(config, {"Agree sets generation", "Finding minimal covers"}),
-      threads_num_(config_.parallelism),
-      max_lhs_(config_.max_lhs) {}
+FastFDs::FastFDs() : PliBasedFDAlgorithm({"Agree sets generation", "Finding minimal covers"}) {
+    RegisterOptions();
+}
 
-FastFDs::FastFDs(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config)
-    : PliBasedFDAlgorithm(std::move(relation), config,
-                          {"Agree sets generation", "Finding minimal covers"}),
-      threads_num_(config_.parallelism),
-      max_lhs_(config_.max_lhs) {}
+void FastFDs::RegisterOptions() {
+    RegisterOption(config::ThreadNumberOpt.GetOption(&threads_num_));
+    RegisterOption(config::MaxLhsOpt.GetOption(&max_lhs_));
+}
+
+void FastFDs::MakeExecuteOptsAvailable() {
+    MakeOptionsAvailable(config::GetOptionNames(config::MaxLhsOpt, config::ThreadNumberOpt));
+}
 
 unsigned long long FastFDs::ExecuteInternal() {
     schema_ = relation_->GetSchema();

--- a/src/algorithms/fastfds.h
+++ b/src/algorithms/fastfds.h
@@ -4,22 +4,25 @@
 
 #include <boost/thread/mutex.hpp>
 
-#include "column_layout_relation_data.h"
-#include "pli_based_fd_algorithm.h"
-#include "vertical.h"
+#include "algorithms/options/max_lhs_opt.h"
+#include "algorithms/options/thread_number_opt.h"
+#include "algorithms/pli_based_fd_algorithm.h"
+#include "model/column_layout_relation_data.h"
+#include "model/vertical.h"
 
 namespace algos {
 
 class FastFDs : public PliBasedFDAlgorithm {
 public:
-    explicit FastFDs(Config const& config);
-    explicit FastFDs(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config);
+    FastFDs();
 
 private:
     using OrderingComparator = std::function<bool(Column const&, Column const&)>;
     using DiffSet = Vertical;
 
-    unsigned long long ExecuteInternal() override;
+    void RegisterOptions();
+    void MakeExecuteOptsAvailable() final;
+    unsigned long long ExecuteInternal() final;
 
     // Computes all difference sets of `relation_` by complementing agree sets
     void GenDiffSets();
@@ -64,8 +67,8 @@ private:
 
     RelationalSchema const* schema_;
     std::vector<DiffSet> diff_sets_;
-    ushort threads_num_;
-    unsigned int const max_lhs_;
+    config::ThreadNumType threads_num_;
+    config::MaxLhsType max_lhs_;
     double percent_per_col_;
 };
 

--- a/src/algorithms/fd_mine.cpp
+++ b/src/algorithms/fd_mine.cpp
@@ -1,10 +1,14 @@
-#include "fd_mine.h"
+#include "algorithms/fd_mine.h"
 
 #include <queue>
 #include <vector>
 
 #include <boost/unordered_map.hpp>
 #include <easylogging++.h>
+
+namespace algos {
+
+Fd_mine::Fd_mine() : PliBasedFDAlgorithm({kDefaultPhaseName}) {}
 
 unsigned long long Fd_mine::ExecuteInternal() {
     // 1
@@ -267,3 +271,4 @@ void Fd_mine::Display() {
     LOG(DEBUG) << "TOTAL FDs " << fd_counter;
 }
 
+}  // namespace algos

--- a/src/algorithms/fd_mine.h
+++ b/src/algorithms/fd_mine.h
@@ -4,11 +4,13 @@
 #include <filesystem>
 #include <set>
 
-#include "column_combination.h"
-#include "column_layout_relation_data.h"
-#include "pli_based_fd_algorithm.h"
-#include "position_list_index.h"
-#include "vertical.h"
+#include "algorithms/pli_based_fd_algorithm.h"
+#include "model/column_combination.h"
+#include "model/column_layout_relation_data.h"
+#include "model/vertical.h"
+#include "util/position_list_index.h"
+
+namespace algos {
 
 class Fd_mine : public PliBasedFDAlgorithm {
 private:
@@ -32,8 +34,9 @@ private:
     void Display();
 
     unsigned long long ExecuteInternal() override;
+
 public:
-    Fd_mine(Config const& config) : PliBasedFDAlgorithm(config, {kDefaultPhaseName}) {}
-    explicit Fd_mine(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config)
-        : PliBasedFDAlgorithm(std::move(relation), config, {kDefaultPhaseName}) {}
+    Fd_mine();
 };
+
+}  // namespace algos

--- a/src/algorithms/fdep/fdep.h
+++ b/src/algorithms/fdep/fdep.h
@@ -3,20 +3,18 @@
 #include <string>
 #include <vector>
 
-#include "fd_algorithm.h"
-#include "fd_tree_element.h"
-#include "relation_data.h"
-#include "relational_schema.h"
+#include "algorithms/fd_algorithm.h"
+#include "algorithms/fdep/fd_tree_element.h"
+#include "model/relation_data.h"
+#include "model/relational_schema.h"
 
 namespace algos {
 
 class FDep : public FDAlgorithm {
 public:
-    explicit FDep(Config const& config);
+    FDep();
 
     ~FDep() override = default;
-
-    unsigned long long ExecuteInternal() override;
 
 private:
     std::unique_ptr<RelationalSchema> schema_{};
@@ -29,8 +27,8 @@ private:
 
     std::vector<std::vector<size_t>> tuples_;
 
-    // Initializing the most common dependencies.
-    void Initialize() override;
+    unsigned long long ExecuteInternal() final;
+    void FitFd(model::IDatasetStream &data_stream) final;
 
     // Building negative cover via violated dependencies
     void BuildNegativeCover();
@@ -46,10 +44,6 @@ private:
     // Specializing general dependencies for not to be followed from violated dependencies of negative cover tree.
     void SpecializePositiveCover(const std::bitset<FDTreeElement::kMaxAttrNum>& lhs,
                                  const size_t& a);
-
-    // Loading the relation
-    // Presented as vector of vectors (tuples of the relation).
-    void LoadData();
 };
 
 }  // namespace algos

--- a/src/algorithms/fun.cpp
+++ b/src/algorithms/fun.cpp
@@ -1,4 +1,4 @@
-#include "fun.h"
+#include "algorithms/fun.h"
 
 #include <easylogging++.h>
 
@@ -19,6 +19,8 @@ bool FunQuadruple::Contains(FunQuadruple const& that) const {
 bool FunQuadruple::Contains(Vertical const& that) const {
     return candidate_.Contains(that);
 }
+
+FUN::FUN() : PliBasedFDAlgorithm({kDefaultPhaseName}) {}
 
 bool FUN::IsKey(FunQuadruple const& l) const {
     return l.GetCount() == relation_->GetNumRows();

--- a/src/algorithms/fun.h
+++ b/src/algorithms/fun.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "pli_based_fd_algorithm.h"
+#include "algorithms/pli_based_fd_algorithm.h"
 #include "custom/custom_hashes.h"
 
 namespace algos {
@@ -75,9 +75,7 @@ public:
 
 class FUN : public PliBasedFDAlgorithm {
 public:
-    explicit FUN(Config const& config) : PliBasedFDAlgorithm(config, {kDefaultPhaseName}) {}
-    explicit FUN(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config)
-        : PliBasedFDAlgorithm(std::move(relation), config, {kDefaultPhaseName}) {}
+    FUN();
 
     // Entities from the algorithm itself
 private:
@@ -86,7 +84,7 @@ private:
 
     using Level = std::list<FunQuadruple>;
 
-    unsigned long long ExecuteInternal() override;
+    unsigned long long ExecuteInternal() final;
 
     Level GenerateCandidate(Level const& l_k) const;
 

--- a/src/algorithms/hyfd/hyfd.cpp
+++ b/src/algorithms/hyfd/hyfd.cpp
@@ -1,8 +1,7 @@
-#include "hyfd.h"
+#include "algorithms/hyfd/hyfd.h"
 
 #include <algorithm>
 #include <chrono>
-#include <iterator>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -11,10 +10,10 @@
 #include <boost/dynamic_bitset.hpp>
 #include <easylogging++.h>
 
-#include "inductor.h"
-#include "sampler.h"
-#include "util/pli_util.h"
-#include "validator.h"
+#include "algorithms/hyfd/inductor.h"
+#include "algorithms/hyfd/sampler.h"
+#include "algorithms/hyfd/util/pli_util.h"
+#include "algorithms/hyfd/validator.h"
 
 namespace {
 
@@ -74,6 +73,8 @@ algos::hyfd::Rows BuildRecordRepresentation(algos::hyfd::Columns const& inverted
 }  // namespace
 
 namespace algos::hyfd {
+
+HyFD::HyFD() : PliBasedFDAlgorithm({}) {}
 
 std::tuple<PLIs, Rows, std::vector<size_t>> HyFD::Preprocess() {
     PLIs plis;

--- a/src/algorithms/hyfd/hyfd.h
+++ b/src/algorithms/hyfd/hyfd.h
@@ -5,10 +5,10 @@
 #include <utility>
 #include <vector>
 
-#include "pli_based_fd_algorithm.h"
-#include "position_list_index.h"
-#include "raw_fd.h"
-#include "types.h"
+#include "algorithms/hyfd/types.h"
+#include "algorithms/pli_based_fd_algorithm.h"
+#include "model/raw_fd.h"
+#include "util/position_list_index.h"
 
 namespace algos::hyfd {
 
@@ -42,9 +42,7 @@ private:
     void RegisterFDs(std::vector<RawFD>&& fds, std::vector<size_t> const& og_mapping);
 
 public:
-    explicit HyFD(Config const& config) : PliBasedFDAlgorithm(config, {}) {}
-    explicit HyFD(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config)
-        : PliBasedFDAlgorithm(std::move(relation), config, {}) {}
+    HyFD();
 };
 
 }  // namespace algos::hyfd

--- a/src/algorithms/legacy_algorithms.h
+++ b/src/algorithms/legacy_algorithms.h
@@ -1,0 +1,4 @@
+#pragma once
+
+/* Algebraic constraints mining algorithm */
+#include "algorithms/ac_algorithm.h"

--- a/src/algorithms/legacy_primitive.h
+++ b/src/algorithms/legacy_primitive.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "algorithms/primitive.h"
+#include "model/idataset_stream.h"
+#include "parser/csv_parser.h"
+
+namespace algos {
+
+class LegacyPrimitive : public Primitive {
+private:
+    void FitInternal([[maybe_unused]] model::IDatasetStream &data_stream) override {}
+
+protected:
+    std::unique_ptr<model::IDatasetStream> input_generator_;
+
+public:
+    constexpr static double kTotalProgressPercent = 100.0;
+
+    LegacyPrimitive(LegacyPrimitive const& other) = delete;
+    LegacyPrimitive& operator=(LegacyPrimitive const& other) = delete;
+    LegacyPrimitive(LegacyPrimitive&& other) = delete;
+    LegacyPrimitive& operator=(LegacyPrimitive&& other) = delete;
+    virtual ~LegacyPrimitive() override = default;
+
+    explicit LegacyPrimitive(std::vector<std::string_view> phase_names)
+            : Primitive(std::move(phase_names)) {
+        ExecutePrepare();
+    }
+
+    LegacyPrimitive(std::unique_ptr<model::IDatasetStream> input_generator_ptr,
+                    std::vector<std::string_view> phase_names)
+            : Primitive(std::move(phase_names)), input_generator_(std::move(input_generator_ptr)) {
+        ExecutePrepare();
+    }
+
+    LegacyPrimitive(std::filesystem::path const &path, char const separator, bool const has_header,
+                    std::vector<std::string_view> phase_names)
+            : Primitive(std::move(phase_names)),
+            input_generator_(std::make_unique<CSVParser>(path, separator, has_header)) {
+        ExecutePrepare();
+    }
+};
+
+}  // namespace algos

--- a/src/algorithms/metric_verifier.h
+++ b/src/algorithms/metric_verifier.h
@@ -8,31 +8,13 @@
 #include <unordered_map>
 #include <vector>
 
-#include "column_layout_relation_data.h"
-#include "column_layout_typed_relation_data.h"
-#include "primitive.h"
-#include "qgram_vector.h"
+#include "algorithms/metric_verifier_enums.h"
+#include "algorithms/primitive.h"
+#include "model/column_layout_relation_data.h"
+#include "model/column_layout_typed_relation_data.h"
+#include "util/qgram_vector.h"
 
 namespace algos {
-
-BETTER_ENUM(Metric, char,
-            euclidean = 0,  /* Standard metric for calculating the distance between numeric
-                             * values */
-            levenshtein,    /* Levenshtein distance between strings */
-            cosine          /* Represent strings as q-gram vectors and calculate cosine distance
-                             * between these vectors */
-)
-
-BETTER_ENUM(MetricAlgo, char,
-            brute = 0,      /* Brute force algorithm. Calculates distance between all possible pairs
-                             * of values and compares them with parameter */
-            approx,         /* 2-approximation brute force algorithm, that skips some distance
-                             * calculations, but may return false positive result */
-            calipers        /* Rotating calipers algorithm for 2d euclidean metric. Computes a
-                             * convex hull of the points and calculates distances between antipodal
-                             * pairs of convex hull, resulting in a significant reduction in the
-                             * number of comparisons */
-)
 
 class MetricVerifier : public algos::Primitive {
 private:

--- a/src/algorithms/metric_verifier_enums.h
+++ b/src/algorithms/metric_verifier_enums.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <enum.h>
+
+namespace algos {
+
+BETTER_ENUM(Metric, char,
+    euclidean = 0,  /* Standard metric for calculating the distance between numeric
+                     * values */
+    levenshtein,    /* Levenshtein distance between strings */
+    cosine          /* Represent strings as q-gram vectors and calculate cosine distance
+                     * between these vectors */
+)
+
+BETTER_ENUM(MetricAlgo, char,
+    brute = 0,      /* Brute force algorithm. Calculates distance between all possible pairs
+                     * of values and compares them with parameter */
+    approx,         /* 2-approximation brute force algorithm, that skips some distance
+                     * calculations, but may return false positive result */
+    calipers        /* Rotating calipers algorithm for 2d euclidean metric. Computes a
+                     * convex hull of the points and calculates distances between
+                     * antipodal pairs of convex hull, resulting in a significant
+                     * reduction in the number of comparisons */
+)
+
+}  // namespace algos

--- a/src/algorithms/options/descriptions.h
+++ b/src/algorithms/options/descriptions.h
@@ -57,4 +57,7 @@ constexpr auto kDRadius = "maximum difference between a value and the most commo
                           "cluster";
 constexpr auto kDRatio = "ratio between the number of deviating values in a cluster and the "
                          "cluster's size";
+constexpr auto kDPreciseAlgorithm = "Algorithm that gives exact FDs for typo miner to compare "
+                                    "against approximate FDs";
+constexpr auto kDApproximateAlgorithm = "Algorithm which gets approximate FDs for typo miner";
 }

--- a/src/algorithms/options/descriptions.h
+++ b/src/algorithms/options/descriptions.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+
+#include "algorithms/metric_verifier_enums.h"
+
+namespace algos {
+
+template<typename BetterEnumType>
+static std::string EnumToAvailableValues() {
+    std::stringstream avail_values;
+
+    avail_values << '[';
+
+    for (auto const& name : BetterEnumType::_names()) {
+        avail_values << name << '|';
+    }
+
+    avail_values.seekp(-1, avail_values.cur);
+    avail_values << ']';
+
+    return avail_values.str();
+}
+
+}  // namespace algos
+
+namespace algos::config::descriptions {
+constexpr auto kDData = "path to CSV file, relative to ./input_data";
+constexpr auto kDSeparator = "CSV separator";
+constexpr auto kDHasHeader = "CSV header presence flag [true|false]";
+constexpr auto kDEqualNulls = "specify whether two NULLs should be considered equal";
+constexpr auto kDThreads = "number of threads to use. If 0, then as many threads are used as the "
+                           "hardware can handle concurrently.";
+constexpr auto kDError = "error threshold value for Approximate FD algorithms";
+constexpr auto kDMaximumLhs = "max considered LHS size";
+constexpr auto kDSeed = "RNG seed";
+constexpr auto kDMinimumSupport = "minimum support value (between 0 and 1)";
+constexpr auto kDMinimumConfidence = "minimum confidence value (between 0 and 1)";
+constexpr auto kDInputFormat = "format of the input dataset for AR mining\n[singular|tabular]";
+constexpr auto kDTIdColumnIndex = "index of the column where a TID is stored";
+constexpr auto kDItemColumnIndex = "index of the column where an item name is stored";
+constexpr auto kDFirstColumnTId = "indicates that the first column contains the transaction IDs";
+const std::string _kDMetric = "metric to use\n" +
+                              EnumToAvailableValues<algos::Metric>();
+const auto kDMetric = _kDMetric.c_str();
+constexpr auto kDLhsIndices = "LHS column indices for metric FD verification";
+constexpr auto kDRhsIndices = "RHS column indices for metric FD verification";
+constexpr auto kDParameter = "metric FD parameter";
+constexpr auto kDDistToNullIsInfinity = "specify whether distance to NULL value is infinity (if "
+                                        "not, it is 0)";
+constexpr auto kDQGramLength = "q-gram length for cosine metric";
+const std::string _kDMetricAlgorithm = "MFD algorithm to use\n" +
+                                       EnumToAvailableValues<algos::MetricAlgo>();
+const auto kDMetricAlgorithm = _kDMetricAlgorithm.c_str();
+constexpr auto kDRadius = "maximum difference between a value and the most common value in a "
+                          "cluster";
+constexpr auto kDRatio = "ratio between the number of deviating values in a cluster and the "
+                         "cluster's size";
+}

--- a/src/algorithms/options/equal_nulls_opt.h
+++ b/src/algorithms/options/equal_nulls_opt.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "algorithms/options/descriptions.h"
+#include "algorithms/options/names.h"
+#include "algorithms/options/type.h"
+
+namespace algos::config {
+using EqNullsType = bool;
+const OptionType<EqNullsType> EqualNullsOpt{{names::kEqualNulls, descriptions::kDEqualNulls}, true};
+}  // namespace algos::config

--- a/src/algorithms/options/error_opt.h
+++ b/src/algorithms/options/error_opt.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "algorithms/options/descriptions.h"
+#include "algorithms/options/names.h"
+#include "algorithms/options/type.h"
+
+namespace algos::config {
+
+using ErrorType = double;
+const OptionType<ErrorType> ErrorOpt{
+        {config::names::kError, config::descriptions::kDError}, 0.01, [](auto value) {
+            if (!(value >= 0 && value <= 1)) {
+                throw std::invalid_argument("ERROR: error should be between 0 and 1.");
+            }
+        }};
+
+}  // namespace algos::config

--- a/src/algorithms/options/info.cpp
+++ b/src/algorithms/options/info.cpp
@@ -1,0 +1,16 @@
+#include "algorithms/options/info.h"
+
+namespace algos::config {
+
+OptionInfo::OptionInfo(std::string_view name, std::string_view description)
+        : name_(name), description_(description) {}
+
+std::string_view OptionInfo::GetName() const {
+    return name_;
+}
+
+std::string_view OptionInfo::GetDescription() const {
+    return description_;
+}
+
+}  // namespace algos::config

--- a/src/algorithms/options/info.h
+++ b/src/algorithms/options/info.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string_view>
+
+namespace algos::config {
+
+struct OptionInfo {
+    OptionInfo(std::string_view name, std::string_view description);
+
+    [[nodiscard]] std::string_view GetName() const;
+    [[nodiscard]] std::string_view GetDescription() const;
+
+private:
+    std::string_view name_;
+    std::string_view description_;
+};
+
+}  // namespace algos::config

--- a/src/algorithms/options/ioption.h
+++ b/src/algorithms/options/ioption.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#include "boost/any.hpp"
+
+namespace algos::config {
+
+class IOption {
+public:
+    virtual void Set(std::optional<boost::any> value_holder) = 0;
+    virtual void Unset() = 0;
+    [[nodiscard]] virtual bool IsSet() const = 0;
+    [[nodiscard]] virtual std::string_view GetName() const = 0;
+    virtual ~IOption() = default;
+};
+
+}  // namespace algos::config

--- a/src/algorithms/options/max_lhs_opt.h
+++ b/src/algorithms/options/max_lhs_opt.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <limits>
+
+#include "algorithms/options/descriptions.h"
+#include "algorithms/options/names.h"
+#include "algorithms/options/type.h"
+
+namespace algos::config {
+
+using MaxLhsType = unsigned int;
+static const config::OptionType<MaxLhsType> MaxLhsOpt{
+        {config::names::kMaximumLhs, config::descriptions::kDMaximumLhs},
+        std::numeric_limits<MaxLhsType>::max()
+};
+
+}  // namespace algos::config

--- a/src/algorithms/options/names.h
+++ b/src/algorithms/options/names.h
@@ -5,10 +5,7 @@ constexpr auto kHelp = "help";
 constexpr auto kTask = "task";
 constexpr auto kAlgorithm = "algorithm";
 constexpr auto kData = "data";
-#define SEPARATOR "separator"
-constexpr auto kSeparatorConfig = SEPARATOR;
-constexpr auto kSeparatorLibArg = SEPARATOR ",s";
-#undef SEPARATOR
+constexpr auto kSeparator = "separator";
 constexpr auto kHasHeader = "has_header";
 constexpr auto kEqualNulls = "is_null_equal_null";
 constexpr auto kThreads = "threads";

--- a/src/algorithms/options/names.h
+++ b/src/algorithms/options/names.h
@@ -31,4 +31,6 @@ constexpr auto kWeight = "weight";
 constexpr auto kBumpsLimit = "bumps_limit";
 constexpr auto kIterationsLimit = "iterations_limit";
 constexpr auto kPairingRule = "pairing_rule";
+constexpr auto kPreciseAlgorithm = "precise_algorithm";
+constexpr auto kApproximateAlgorithm = "approximate_algorithm";
 }  // namespace algos::config::names

--- a/src/algorithms/options/names.h
+++ b/src/algorithms/options/names.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace program_option_strings {
+namespace algos::config::names {
 constexpr auto kHelp = "help";
 constexpr auto kTask = "task";
 constexpr auto kAlgorithm = "algorithm";
@@ -37,4 +37,4 @@ constexpr auto kWeight = "weight";
 constexpr auto kBumpsLimit = "bumps_limit";
 constexpr auto kIterationsLimit = "iterations_limit";
 constexpr auto kPairingRule = "pairing_rule";
-}  // namespace program_option_strings
+}  // namespace algos::config::names

--- a/src/algorithms/options/names.h
+++ b/src/algorithms/options/names.h
@@ -1,9 +1,6 @@
 #pragma once
 
 namespace algos::config::names {
-constexpr auto kHelp = "help";
-constexpr auto kTask = "task";
-constexpr auto kAlgorithm = "algorithm";
 constexpr auto kData = "data";
 constexpr auto kSeparator = "separator";
 constexpr auto kHasHeader = "has_header";

--- a/src/algorithms/options/names.h
+++ b/src/algorithms/options/names.h
@@ -1,8 +1,3 @@
-//
-// Created by Shlyonskikh Alexey on 2022-07-30.
-// https://github.com/BUYT-1
-//
-
 #pragma once
 
 namespace program_option_strings {

--- a/src/algorithms/options/opt_add_func_type.h
+++ b/src/algorithms/options/opt_add_func_type.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <functional>
+#include <string_view>
+
+namespace algos::config {
+using OptAddFunc = std::function<void(std::string_view, std::vector<std::string_view> const &)>;
+}  // namespace algos::config

--- a/src/algorithms/options/opt_add_func_type.h
+++ b/src/algorithms/options/opt_add_func_type.h
@@ -4,5 +4,5 @@
 #include <string_view>
 
 namespace algos::config {
-using OptAddFunc = std::function<void(std::string_view, std::vector<std::string_view> const &)>;
+using OptAddFunc = std::function<void(IOption *, std::vector<std::string_view> const &)>;
 }  // namespace algos::config

--- a/src/algorithms/options/option.h
+++ b/src/algorithms/options/option.h
@@ -8,6 +8,7 @@
 
 #include "algorithms/options/info.h"
 #include "algorithms/options/ioption.h"
+#include "algorithms/options/opt_add_func_type.h"
 
 namespace algos::config {
 template<typename T>
@@ -15,7 +16,6 @@ class Option : public IOption {
 public:
     using CondCheckFunc = std::function<bool(T const &val)>;
     using OptCondVector = std::vector<std::pair<CondCheckFunc, std::vector<std::string_view>>>;
-    using OptAddFunc = std::function<void(std::string_view, std::vector<std::string_view> const&)>;
     using DefaultFunc = std::function<T()>;
     using NormalizeFunc = std::function<void(T &)>;
     using InstanceCheckFunc = std::function<void(T const &)>;

--- a/src/algorithms/options/option.h
+++ b/src/algorithms/options/option.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <optional>
+
+#include <boost/any.hpp>
+
+#include "algorithms/options/info.h"
+#include "algorithms/options/ioption.h"
+
+namespace algos::config {
+template<typename T>
+class Option : public IOption {
+public:
+    using CondCheckFunc = std::function<bool(T const &val)>;
+    using OptCondVector = std::vector<std::pair<CondCheckFunc, std::vector<std::string_view>>>;
+    using OptAddFunc = std::function<void(std::string_view, std::vector<std::string_view> const&)>;
+    using DefaultFunc = std::function<T()>;
+    using NormalizeFunc = std::function<void(T &)>;
+    using InstanceCheckFunc = std::function<void(T const &)>;
+
+    Option(OptionInfo const info, T *value_ptr, NormalizeFunc normalize,
+           std::optional<T> default_value)
+            : info_(info),
+              value_ptr_(value_ptr),
+              normalize_(normalize),
+              default_func_(default_value.has_value()
+                            ? [default_value]() { return default_value.value(); }
+                            : DefaultFunc{}) {}
+
+    void Set(std::optional<boost::any> value_holder) override;
+
+    T GetValue(std::optional<boost::any> value_holder) const;
+
+    void Unset() override {
+        is_set_ = false;
+    }
+
+    [[nodiscard]] std::string_view GetName() const override {
+        return info_.GetName();
+    }
+
+    [[nodiscard]] std::string_view GetDescription() const {
+        return info_.GetDescription();
+    }
+
+    [[nodiscard]] bool IsSet() const override {
+        return is_set_;
+    }
+
+    Option &SetInstanceCheck(InstanceCheckFunc instance_check) {
+        instance_check_ = instance_check;
+        return *this;
+    }
+
+    Option &SetConditionalOpts(OptAddFunc const &add_opts, OptCondVector opt_cond) {
+        assert(add_opts);
+        assert(!opt_cond.empty());
+        opt_cond_ = std::move(opt_cond);
+        opt_add_func_ = add_opts;
+        return *this;
+    }
+
+    Option &OverrideDefaultValue(std::optional<T> new_default) {
+        default_func_ = new_default.has_value()
+                        ? [new_default]() { return new_default.value(); }
+                        : DefaultFunc{};
+        return *this;
+    }
+
+    Option &OverrideDefaultFunction(DefaultFunc default_func) {
+        default_func_ = default_func;
+        return *this;
+    }
+
+private:
+    bool is_set_ = false;
+    OptionInfo const info_;
+    T *value_ptr_;
+    NormalizeFunc normalize_{};
+    DefaultFunc default_func_;
+    InstanceCheckFunc instance_check_{};
+    OptCondVector opt_cond_{};
+    OptAddFunc opt_add_func_{};
+};
+
+template <typename T>
+void Option<T>::Set(std::optional<boost::any> value_holder) {
+    assert(!is_set_);
+    T value = GetValue(value_holder);
+    if (normalize_) normalize_(value);
+    if (instance_check_) instance_check_(value);
+
+    assert(value_ptr_ != nullptr);
+    *value_ptr_ = value;
+    is_set_ = true;
+    if (opt_add_func_) {
+        for (auto const &[cond, opts]: opt_cond_) {
+            if (!cond || cond(value)) {
+                opt_add_func_(this, opts);
+                break;
+            }
+        }
+    }
+}
+
+template <typename T>
+T Option<T>::GetValue(std::optional<boost::any> value_holder) const {
+    std::string const no_value_no_default =
+            std::string("No value was provided to an option without a default value (")
+            + info_.GetName().data() + ")";
+    if (!value_holder.has_value()) {
+        if (!default_func_) throw std::logic_error(no_value_no_default);
+        return default_func_();
+    } else {
+        return boost::any_cast<T>(value_holder.value());
+    }
+}
+
+}  // namespace algos::config

--- a/src/algorithms/options/thread_number_opt.h
+++ b/src/algorithms/options/thread_number_opt.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <thread>
+
+#include "algorithms/options/descriptions.h"
+#include "algorithms/options/names.h"
+#include "algorithms/options/type.h"
+
+namespace algos::config {
+
+using ThreadNumType = ushort;
+const OptionType<ThreadNumType> ThreadNumberOpt{
+        {names::kThreads, descriptions::kDThreads}, 0, [](auto &value) {
+            if (value == 0) {
+                value = std::thread::hardware_concurrency();
+                if (value == 0) {
+                    throw std::runtime_error(
+                            "Unable to detect number of concurrent "
+                            "threads supported by your system. "
+                            "Please, specify it manually.");
+                }
+            }
+        }};
+
+}  // namespace algos::config

--- a/src/algorithms/options/type.h
+++ b/src/algorithms/options/type.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <optional>
+
+#include "algorithms/options/option.h"
+
+namespace algos::config {
+
+template<typename T>
+struct OptionType {
+    explicit OptionType(OptionInfo const info, std::optional<T> default_value = {},
+                        typename Option<T>::NormalizeFunc normalize = {})
+            : info_(info), default_value_(std::move(default_value)),
+              normalize_(std::move(normalize)) {}
+
+    [[nodiscard]] Option<T> GetOption(T *value_ptr) const {
+        return {info_, value_ptr, normalize_, default_value_};
+    }
+
+    [[nodiscard]] std::string_view GetName() const {
+        return info_.GetName();
+    }
+
+private:
+    OptionInfo const info_;
+    std::optional<T> const default_value_;
+    std::function<void(T &)> const normalize_;
+};
+
+template<typename... Types>
+std::vector<std::string_view> GetOptionNames(OptionType<Types> const &... options) {
+    std::vector<std::string_view> names{};
+    (names.emplace_back(options.GetName()), ...);
+    return names;
+}
+
+}

--- a/src/algorithms/pli_based_fd_algorithm.cpp
+++ b/src/algorithms/pli_based_fd_algorithm.cpp
@@ -1,10 +1,12 @@
-#include "pli_based_fd_algorithm.h"
+#include "algorithms/pli_based_fd_algorithm.h"
 
-void PliBasedFDAlgorithm::Initialize() {
-    if (relation_ == nullptr) {
-        relation_ =
-            ColumnLayoutRelationData::CreateFrom(*input_generator_, config_.is_null_equal_null);
-    }
+namespace algos {
+
+PliBasedFDAlgorithm::PliBasedFDAlgorithm(std::vector<std::string_view> phase_names)
+        : FDAlgorithm(std::move(phase_names)) {}
+
+void PliBasedFDAlgorithm::FitFd(model::IDatasetStream& data_stream) {
+    relation_ = ColumnLayoutRelationData::CreateFrom(data_stream, is_null_equal_null_);
 
     if (relation_->GetColumnData().empty()) {
         throw std::runtime_error("Got an empty dataset: FD mining is meaningless.");
@@ -23,3 +25,14 @@ std::vector<Column const*> PliBasedFDAlgorithm::GetKeys() const {
 
     return keys;
 }
+
+void PliBasedFDAlgorithm::Fit(std::shared_ptr<ColumnLayoutRelationData> data) {
+    if (data->GetColumnData().empty()) {
+        throw std::runtime_error("Got an empty dataset: FD mining is meaningless.");
+    }  // TODO: this has to be repeated for every "alternative" Fit
+    number_of_columns_ = data->GetNumColumns();
+    relation_ = std::move(data);
+    ExecutePrepare();  // TODO: this has to be repeated for every "alternative" Fit
+}
+
+}  // namespace algos

--- a/src/algorithms/pli_based_fd_algorithm.h
+++ b/src/algorithms/pli_based_fd_algorithm.h
@@ -1,16 +1,15 @@
 #pragma once
 
-#include "column_layout_relation_data.h"
-#include "fd_algorithm.h"
+#include "algorithms/fd_algorithm.h"
+#include "model/column_layout_relation_data.h"
+
+namespace algos {
 
 class PliBasedFDAlgorithm : public FDAlgorithm {
-private:
-    using algos::Primitive::input_generator_;
-
-    void Initialize() override;
-
 protected:
     std::shared_ptr<ColumnLayoutRelationData> relation_;
+
+    void FitFd(model::IDatasetStream& data_stream) final;
 
     ColumnLayoutRelationData const& GetRelation() const noexcept {
         // GetRelation should be called after the dataset has been parsed, i.e. after algorithm
@@ -20,12 +19,12 @@ protected:
     }
 
 public:
-    explicit PliBasedFDAlgorithm(Config const& config, std::vector<std::string_view> phase_names)
-        : FDAlgorithm(config, std::move(phase_names)) {}
-
-    explicit PliBasedFDAlgorithm(std::shared_ptr<ColumnLayoutRelationData> relation,
-                                 Config const& config, std::vector<std::string_view> phase_names)
-        : FDAlgorithm(config, std::move(phase_names)), relation_(std::move(relation)) {}
+    explicit PliBasedFDAlgorithm(std::vector<std::string_view> phase_names);
 
     std::vector<Column const*> GetKeys() const override;
+
+    using Primitive::Fit;
+    void Fit(std::shared_ptr<ColumnLayoutRelationData> data);
 };
+
+}  // namespace algos

--- a/src/algorithms/primitive.cpp
+++ b/src/algorithms/primitive.cpp
@@ -93,6 +93,7 @@ void Primitive::Fit(model::IDatasetStream& data) {
     if (!GetNeededOptions().empty()) throw std::logic_error(
                 "All options need to be set before starting processing.");
     FitInternal(data);
+    data.Reset();
     ExecutePrepare();
 }
 

--- a/src/algorithms/primitive.cpp
+++ b/src/algorithms/primitive.cpp
@@ -9,7 +9,11 @@ bool Primitive::HandleUnknownOption([[maybe_unused]] std::string_view const& opt
     return false;
 }
 
-void Primitive::AddMoreNeededOptions(
+bool Primitive::FitCompleted() const {
+    return fit_completed_;
+}
+
+void Primitive::AddSpecificNeededOptions(
         [[maybe_unused]] std::unordered_set<std::string_view> &previous_options) const {}
 
 void Primitive::MakeExecuteOptsAvailable() {}
@@ -127,7 +131,7 @@ std::unordered_set<std::string_view> Primitive::GetNeededOptions() const {
             needed.insert(name);
         }
     }
-    AddMoreNeededOptions(needed);
+    AddSpecificNeededOptions(needed);
     return needed;
 }
 

--- a/src/algorithms/primitive.cpp
+++ b/src/algorithms/primitive.cpp
@@ -1,26 +1,142 @@
-#include "primitive.h"
+#include "algorithms/primitive.h"
 
 #include <cassert>
 
-void algos::Primitive::AddProgress(double const val) noexcept {
+namespace algos {
+
+bool Primitive::HandleUnknownOption([[maybe_unused]] std::string_view const& option_name,
+                                    [[maybe_unused]] std::optional<boost::any> const& value) {
+    return false;
+}
+
+void Primitive::AddMoreNeededOptions(
+        [[maybe_unused]] std::unordered_set<std::string_view> &previous_options) const {}
+
+void Primitive::MakeExecuteOptsAvailable() {}
+
+config::OptAddFunc Primitive::GetOptAvailFunc() {
+    return [this](auto parent_opt, auto children) { MakeOptionsAvailable(parent_opt, children); };
+}
+
+void Primitive::ClearOptions() noexcept {
+    available_options.clear();
+    opt_parents_.clear();
+}
+
+void Primitive::ExecutePrepare() {
+    fit_completed_ = true;
+    ClearOptions();
+    MakeExecuteOptsAvailable();
+}
+
+Primitive::Primitive(std::vector<std::string_view> phase_names)
+        : phase_names_(std::move(phase_names)) {}
+
+void Primitive::MakeOptionsAvailable(config::IOption *parent,
+                                     std::vector<std::string_view> const &option_names) {
+    MakeOptionsAvailable(option_names);
+    auto it = possible_options_.find(parent->GetName());
+    assert(it != possible_options_.end());
+    for (const auto &option_name: option_names) {
+        opt_parents_[it->first].emplace_back(option_name);
+    }
+}
+
+void Primitive::ExcludeOptions(std::string_view parent_option) noexcept {
+    auto it = opt_parents_.find(parent_option);
+    if (it == opt_parents_.end()) return;
+
+    for (auto const &option_name: it->second) {
+        auto possible_opt_it = possible_options_.find(option_name);
+        assert(possible_opt_it != possible_options_.end());
+        available_options.erase(possible_opt_it->first);
+        UnsetOption(possible_opt_it->first);
+    }
+    opt_parents_.erase(it);
+}
+
+void Primitive::UnsetOption(std::string_view option_name) noexcept {
+    auto it = possible_options_.find(option_name);
+    if (it == possible_options_.end()
+        || available_options.find(it->first) == available_options.end())
+        return;
+    it->second->Unset();
+    ExcludeOptions(it->first);
+}
+
+void Primitive::AddProgress(double const val) noexcept {
     assert(val >= 0);
     std::scoped_lock lock(progress_mutex_);
     cur_phase_progress_ += val;
     assert(cur_phase_progress_ < 101);
 }
 
-void algos::Primitive::SetProgress(double const val) noexcept {
+void Primitive::SetProgress(double const val) noexcept {
     assert(0 <= val && val < 101);
     std::scoped_lock lock(progress_mutex_);
     cur_phase_progress_ = val;
 }
 
-std::pair<uint8_t, double> algos::Primitive::GetProgress() const noexcept {
+void Primitive::MakeOptionsAvailable(const std::vector<std::string_view> &option_names) {
+    for (std::string_view name: option_names) {
+        auto it = possible_options_.find(name);
+        assert(it != possible_options_.end());
+        available_options.insert(it->first);
+    }
+}
+
+void Primitive::Fit(model::IDatasetStream& data) {
+    if (!GetNeededOptions().empty()) throw std::logic_error(
+                "All options need to be set before starting processing.");
+    FitInternal(data);
+    ExecutePrepare();
+}
+
+unsigned long long Primitive::Execute() {
+    if (!fit_completed_) {
+        throw std::logic_error("Data must be processed before execution.");
+    }
+    if (!GetNeededOptions().empty())
+        throw std::logic_error("All options need to be set before execution.");
+    return ExecuteInternal();
+}
+
+void Primitive::SetOption(std::string_view const& option_name,
+                          std::optional<boost::any> const& value) {
+    auto it = possible_options_.find(option_name);
+    if (it == possible_options_.end()) {
+        if (!HandleUnknownOption(option_name, value)) {
+            throw std::invalid_argument("Unknown option \"" + std::string{option_name} + '"');
+        }
+        return;
+    } else if (available_options.find(it->first) == available_options.end()) {
+        throw std::invalid_argument("Invalid option \"" + std::string{option_name} + '"');
+    }
+
+    if (it->second->IsSet()) {
+        UnsetOption(it->first);
+    }
+
+    it->second->Set(value);
+}
+
+std::unordered_set<std::string_view> Primitive::GetNeededOptions() const {
+    std::unordered_set<std::string_view> needed{};
+    for (std::string_view name : available_options) {
+        if (!possible_options_.at(name)->IsSet()) {
+            needed.insert(name);
+        }
+    }
+    AddMoreNeededOptions(needed);
+    return needed;
+}
+
+std::pair<uint8_t, double> Primitive::GetProgress() const noexcept {
     std::scoped_lock lock(progress_mutex_);
     return std::make_pair(cur_phase_id_, cur_phase_progress_);
 }
 
-void algos::Primitive::ToNextProgressPhase() noexcept {
+void Primitive::ToNextProgressPhase() noexcept {
     /* Current phase done, ensure that this is displayed in the progress bar */
     SetProgress(kTotalProgressPercent);
 
@@ -29,3 +145,5 @@ void algos::Primitive::ToNextProgressPhase() noexcept {
     assert(cur_phase_id_ < phase_names_.size());
     cur_phase_progress_ = 0;
 }
+
+}  // namespace algos

--- a/src/algorithms/primitive.h
+++ b/src/algorithms/primitive.h
@@ -64,9 +64,8 @@ protected:
     // possible_options_ map. Useful for pipelines.
     virtual bool HandleUnknownOption(std::string_view const& option_name,
                                      std::optional<boost::any> const& value);
-    virtual void AddMoreNeededOptions(std::unordered_set<std::string_view>& previous_options) const;
-
-    // Call this after if your primitive has an alternative Fit
+    virtual void AddSpecificNeededOptions(
+            std::unordered_set<std::string_view>& previous_options) const;
     void ExecutePrepare();
 
     // Overload this to add options after your primitive has processed the data
@@ -85,6 +84,7 @@ public:
     explicit Primitive(std::vector<std::string_view> phase_names);
 
     void Fit(model::IDatasetStream & data_stream);
+    bool FitCompleted() const;
 
     unsigned long long Execute();
 

--- a/src/algorithms/pyro.h
+++ b/src/algorithms/pyro.h
@@ -3,16 +3,16 @@
 #include <list>
 #include <mutex>
 
-#include "dependency_consumer.h"
-#include "pli_based_fd_algorithm.h"
-#include "search_space.h"
+#include "algorithms/options/type.h"
+#include "algorithms/pli_based_fd_algorithm.h"
+#include "core/dependency_consumer.h"
+#include "core/search_space.h"
 
 namespace algos {
 
 class Pyro : public DependencyConsumer, public PliBasedFDAlgorithm {
 private:
-    constexpr static const char* kSeed = "seed";
-    constexpr static const char* kMaxError = "error";
+    static config::OptionType<decltype(Configuration::seed)> SeedOpt;
 
     std::list<std::unique_ptr<SearchSpace>> search_spaces_;
 
@@ -22,12 +22,12 @@ private:
 
     Configuration configuration_;
 
-    unsigned long long ExecuteInternal() override;
-    void init();
+    void RegisterOptions();
+    void MakeExecuteOptsAvailable() final;
+    unsigned long long ExecuteInternal() final;
 
 public:
-    explicit Pyro(Config const& config);
-    explicit Pyro(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config);
+    Pyro();
 };
 
 }  // namespace algos

--- a/src/algorithms/statistics/csv_stats.h
+++ b/src/algorithms/statistics/csv_stats.h
@@ -1,21 +1,30 @@
 #pragma once
 
-#include "column_layout_typed_relation_data.h"
-#include "fd_algorithm.h"
-#include "statistic.h"
+#include "algorithms/fd_algorithm.h"
+#include "algorithms/options/equal_nulls_opt.h"
+#include "algorithms/options/thread_number_opt.h"
+#include "algorithms/statistics/statistic.h"
+#include "model/column_layout_typed_relation_data.h"
 
 namespace algos {
 
-class CsvStats : public algos::Primitive {
-    FDAlgorithm::Config config_;
-    const std::vector<model::TypedColumnData> col_data_;
+class CsvStats : public Primitive {
+    config::EqNullsType is_null_equal_null_;
+    config::ThreadNumType threads_num_;
+
+    std::vector<model::TypedColumnData> col_data_;
     std::vector<ColumnStats> all_stats_;
-    ushort threads_num_;
 
     size_t MixedDistinct(size_t index) const;
+    void RegisterOptions();
+
+protected:
+    void FitInternal(model::IDatasetStream &data_stream) final;
+    void MakeExecuteOptsAvailable() final;
+    unsigned long long ExecuteInternal() final;
 
 public:
-    explicit CsvStats(const FDAlgorithm::Config& config);
+    CsvStats();
 
     const std::vector<model::TypedColumnData>& GetData() const noexcept;
 
@@ -61,7 +70,6 @@ public:
     const ColumnStats& GetAllStats(size_t index) const;
     const std::vector<ColumnStats>& GetAllStats() const;
     std::string ToString() const;
-    unsigned long long Execute();
 };
 
 }  // namespace algos

--- a/src/algorithms/tane.cpp
+++ b/src/algorithms/tane.cpp
@@ -1,3 +1,5 @@
+#include "algorithms/tane.h"
+
 #include <easylogging++.h>
 
 #include <chrono>
@@ -5,15 +7,27 @@
 #include <list>
 #include <memory>
 
-#include "column_combination.h"
-#include "column_data.h"
-#include "column_layout_relation_data.h"
-#include "lattice_level.h"
-#include "lattice_vertex.h"
-#include "relational_schema.h"
-#include "tane.h"
+#include "model/column_combination.h"
+#include "model/column_data.h"
+#include "model/column_layout_relation_data.h"
+#include "model/relational_schema.h"
+#include "util/lattice_level.h"
+#include "util/lattice_vertex.h"
 
 namespace algos {
+
+Tane::Tane() : PliBasedFDAlgorithm({kDefaultPhaseName})  {
+    RegisterOptions();
+}
+
+void Tane::RegisterOptions() {
+    RegisterOption(config::MaxLhsOpt.GetOption(&max_lhs_));
+    RegisterOption(config::ErrorOpt.GetOption(&max_ucc_error_));
+}
+
+void Tane::MakeExecuteOptsAvailable() {
+    MakeOptionsAvailable(config::GetOptionNames(config::MaxLhsOpt, config::ErrorOpt));
+}
 
 double Tane::CalculateZeroAryFdError(ColumnData const* rhs,
                                      ColumnLayoutRelationData const* relation_data) {
@@ -54,6 +68,7 @@ void Tane::RegisterUcc([[maybe_unused]] Vertical const& key,
 }
 
 unsigned long long Tane::ExecuteInternal() {
+    max_fd_error_ = max_ucc_error_;
     RelationalSchema const* schema = relation_->GetSchema();
 
     LOG(INFO) << schema->GetName() << " has " << relation_->GetNumColumns() << " columns, "

--- a/src/algorithms/tane.h
+++ b/src/algorithms/tane.h
@@ -2,38 +2,30 @@
 
 #include <string>
 
-#include "pli_based_fd_algorithm.h"
-#include "position_list_index.h"
-#include "relation_data.h"
+#include "algorithms/options/error_opt.h"
+#include "algorithms/options/max_lhs_opt.h"
+#include "algorithms/pli_based_fd_algorithm.h"
+#include "model/relation_data.h"
+#include "util/position_list_index.h"
 
 namespace algos {
 
 class Tane : public PliBasedFDAlgorithm {
 private:
-    /* Special config parameters */
-    constexpr static const char* kMaxError = "error";
+    void RegisterOptions();
+    void MakeExecuteOptsAvailable() final;
+    unsigned long long ExecuteInternal() final;
 
-    unsigned long long ExecuteInternal() override;
 public:
-    //TODO: these consts should go in class (or struct) Configuration
-    const double max_fd_error_ = 0.01;
-    const double max_ucc_error_ = 0.01;
-    const unsigned int max_lhs_ = -1;
+    config::ErrorType max_fd_error_;
+    config::ErrorType max_ucc_error_;
+    config::MaxLhsType max_lhs_;
 
     int count_of_fd_ = 0;
     int count_of_ucc_ = 0;
     long apriori_millis_ = 0;
 
-    explicit Tane(Config const& config)
-        : PliBasedFDAlgorithm(config, {kDefaultPhaseName}),
-          max_fd_error_(GetSpecialParam<double>(kMaxError)),
-          max_ucc_error_(GetSpecialParam<double>(kMaxError)),
-          max_lhs_(config_.max_lhs) {}
-    explicit Tane(std::shared_ptr<ColumnLayoutRelationData> relation, Config const& config)
-        : PliBasedFDAlgorithm(std::move(relation), config, {kDefaultPhaseName}),
-          max_fd_error_(GetSpecialParam<double>(kMaxError)),
-          max_ucc_error_(GetSpecialParam<double>(kMaxError)),
-          max_lhs_(config_.max_lhs) {}
+    Tane();
 
     static double CalculateZeroAryFdError(ColumnData const* rhs,
                                           ColumnLayoutRelationData const* relation_data);

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "algorithms/options/names.h"
 #include "column_layout_typed_relation_data.h"
 #include "csv_parser.h"
 #include "idataset_stream.h"
 #include "primitive.h"
-#include "program_option_strings.h"
 #include "pyro.h"
 #include "types.h"
 

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "algorithms/options/names.h"
-#include "column_layout_typed_relation_data.h"
-#include "csv_parser.h"
-#include "idataset_stream.h"
-#include "primitive.h"
-#include "pyro.h"
+#include "algorithms/primitive.h"
+#include "algorithms/pyro.h"
+#include "model/column_layout_typed_relation_data.h"
+#include "model/idataset_stream.h"
+#include "parser/csv_parser.h"
 #include "types.h"
 
 namespace algos {
@@ -144,14 +144,14 @@ std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
     static_assert(std::is_base_of_v<PliBasedFDAlgorithm, ApproxAlgo>,
                   "Approximate algorithm must be relation based");
 
-    namespace posr = program_option_strings;
+    namespace onam = algos::config::names;
 
-    if (config.GetSpecialParam<double>(posr::kError) == 0.0) {
+    if (config.GetSpecialParam<double>(onam::kError) == 0.0) {
         throw std::invalid_argument("Typo mining with error = 0 is meaningless");
     }
 
     Config precise_config = config;
-    precise_config.special_params[posr::kError] = 0.0;
+    precise_config.special_params[onam::kError] = 0.0;
     auto input_generator = std::make_unique<CSVParser>(config.data, config.separator,
                                                        config.has_header);
     std::shared_ptr<ColumnLayoutRelationData> relation = ColumnLayoutRelationData::CreateFrom(
@@ -162,11 +162,11 @@ std::unique_ptr<TypoMiner> TypoMiner::CreateFrom(Config const& config) {
 
     double radius;
     double ratio;
-    if (config.HasParam(posr::kRadius)) {
-        radius = VerifyRadius(config.GetSpecialParam<double>(posr::kRadius));
+    if (config.HasParam(onam::kRadius)) {
+        radius = VerifyRadius(config.GetSpecialParam<double>(onam::kRadius));
     }
-    if (config.HasParam(posr::kRatio)) {
-        ratio = VerifyRatio(config.GetSpecialParam<double>(posr::kRatio));
+    if (config.HasParam(onam::kRatio)) {
+        ratio = VerifyRatio(config.GetSpecialParam<double>(onam::kRatio));
     } else {
         /* Should be good heuristic. Or set ratio to 1 by default? */
         ratio = (relation->GetNumRows() <= 1) ? 1 : 2.0 / relation->GetNumRows();

--- a/src/core/configuration.h
+++ b/src/core/configuration.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "algorithms/options/thread_number_opt.h"
+
 struct Configuration {
     bool is_find_keys = true;
     bool is_find_fds = true;
@@ -15,7 +17,7 @@ struct Configuration {
     double max_ucc_error = 0.01;          // both for FD and UCC actually
 
     //Traversal settings
-    int parallelism = 0;
+    algos::config::ThreadNumType parallelism = 0;
     int max_threads_per_search_space = -1;
     bool is_defer_failed_launch_pads = true;
     std::string launch_pad_order = "error";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,8 @@
 #include <easylogging++.h>
 
 #include "algorithms/algo_factory.h"
+#include "algorithms/ar_algorithm_enums.h"
+#include "algorithms/metric_verifier_enums.h"
 #include "algorithms/options/descriptions.h"
 #include "algorithms/options/names.h"
 #include "algorithms/create_primitive.h"
@@ -37,6 +39,24 @@ void validate(boost::any& v, const std::vector<std::string>& values, MetricAlgo*
     const std::string& s = po::validators::get_single_string(values);
     try {
         v = boost::any(MetricAlgo::_from_string_nocase(s.c_str()));
+    } catch (std::runtime_error &e) {
+        throw po::validation_error(po::validation_error::invalid_option_value);
+    }
+}
+
+void validate(boost::any& v, const std::vector<std::string>& values, PrimitiveType*, int) {
+    const std::string& s = po::validators::get_single_string(values);
+    try {
+        v = boost::any(PrimitiveType::_from_string_nocase(s.c_str()));
+    } catch (std::runtime_error &e) {
+        throw po::validation_error(po::validation_error::invalid_option_value);
+    }
+}
+
+void validate(boost::any& v, const std::vector<std::string>& values, InputFormat*, int) {
+    const std::string& s = po::validators::get_single_string(values);
+    try {
+        v = boost::any(InputFormat::_from_string_nocase(s.c_str()));
     } catch (std::runtime_error &e) {
         throw po::validation_error(po::validation_error::invalid_option_value);
     }
@@ -79,11 +99,20 @@ int main(int argc, char const* argv[]) {
             (onam::kThreads, po::value<ushort>(), desc::kDThreads)
             ;
 
-    po::options_description typos_fd_options("Typo mining/FD options");
-    typos_fd_options.add_options()
+    po::options_description fd_options("FD options");
+    fd_options.add_options()
             (onam::kError, po::value<double>(), desc::kDError)
             (onam::kMaximumLhs, po::value<unsigned int>(), desc::kDMaximumLhs)
             (onam::kSeed, po::value<int>(), desc::kDSeed)
+            ;
+
+    po::options_description typo_options("Typo mining options");
+    typo_options.add_options()
+            (onam::kRatio, po::value<double>(), desc::kDRatio)
+            (onam::kRadius, po::value<double>(), desc::kDRadius)
+            (onam::kApproximateAlgorithm, po::value<algos::PrimitiveType>(),
+             desc::kDApproximateAlgorithm)
+            (onam::kPreciseAlgorithm, po::value<algos::PrimitiveType>(), desc::kDPreciseAlgorithm)
             ;
 
     po::options_description ar_options("AR options");
@@ -146,8 +175,8 @@ int main(int argc, char const* argv[]) {
         ;
 
     po::options_description all_options("Allowed options");
-    all_options.add(info_options).add(general_options).add(typos_fd_options)
-        .add(mfd_options).add(ar_options).add(ac_options);
+    all_options.add(info_options).add(general_options).add(fd_options)
+        .add(mfd_options).add(ar_options).add(ac_options).add(typo_options);
 
     po::variables_map vm;
     try {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,20 +1,18 @@
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <iostream>
-#include <iterator>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 #include <easylogging++.h>
 
 #include "algorithms/algo_factory.h"
 #include "algorithms/options/descriptions.h"
 #include "algorithms/options/names.h"
+#include "algorithms/create_primitive.h"
 
 namespace po = boost::program_options;
 namespace onam = algos::config::names;
@@ -24,164 +22,106 @@ using algos::EnumToAvailableValues;
 
 INITIALIZE_EASYLOGGINGPP
 
-static bool CheckOptions(std::string const& task, std::string const& alg, std::string const& metric,
-                         std::string const& metric_alg, size_t rhs_indices_count, double error) {
-    if (!algos::AlgoMiningType::_is_valid(task.c_str())) {
-        std::cout << "ERROR: no matching task."
-                     " Available tasks (primitives to mine) are:\n" +
-                     EnumToAvailableValues<algos::AlgoMiningType>() + '\n';
-        return false;
-    }
+namespace algos {
 
-    if (task == "metric") {
-        if (!algos::Metric::_is_valid(metric.c_str())) {
-            std::cout << "ERROR: no matching metric."
-                         " Available metrics are:\n" +
-                         EnumToAvailableValues<algos::Metric>() + '\n';
-            return false;
-        }
-        if (rhs_indices_count == 1 && metric == "euclidean") {
-            if (!metric_alg.empty()) {
-                std::cout << "metric_algo is ignored for one-dimensional euclidean metric.\n";
-            }
-            return true;
-        }
-        if (!algos::MetricAlgo::_is_valid(metric_alg.c_str())) {
-            std::cout << "ERROR: no matching MFD algorithm."
-                         " Available MFD algorithms are:\n" +
-                         EnumToAvailableValues<algos::MetricAlgo>() + '\n';
-            return false;
-        }
-        return true;
+void validate(boost::any& v, const std::vector<std::string>& values, Metric*, int) {
+    const std::string& s = po::validators::get_single_string(values);
+    try {
+        v = boost::any(Metric::_from_string_nocase(s.c_str()));
+    } catch (std::runtime_error&e) {
+        throw po::validation_error(po::validation_error::invalid_option_value);
     }
-
-    if (!algos::Algo::_is_valid(alg.c_str())) {
-        std::cout << "ERROR: no matching algorithm."
-                     " Available algorithms are:\n" +
-                     EnumToAvailableValues<algos::Algo>() + '\n';
-        return false;
-    }
-
-    if (error > 1 || error < 0) {
-        std::cout << "ERROR: error should be between 0 and 1.\n";
-    }
-
-    return true;
 }
 
+void validate(boost::any& v, const std::vector<std::string>& values, MetricAlgo*, int) {
+    const std::string& s = po::validators::get_single_string(values);
+    try {
+        v = boost::any(MetricAlgo::_from_string_nocase(s.c_str()));
+    } catch (std::runtime_error &e) {
+        throw po::validation_error(po::validation_error::invalid_option_value);
+    }
+}
+
+}  // namespace algos
+
 int main(int argc, char const* argv[]) {
-    std::string algo;
-    std::string dataset;
-    std::string task;
-    char separator = ',';
-    bool has_header = true;
-    int seed = 0;
-    double error = 0.0;
-    unsigned int max_lhs = -1;
-    ushort threads = 0;
-    bool is_null_equal_null = true;
-
-    /*Options for association rule mining algorithms*/
-    double minsup = 0.0;
-    double minconf = 0.0;
-    std::string ar_input_format;
-    unsigned tid_column_index = 0;
-    unsigned item_column_index = 1;
-    bool has_transaction_id = false;
-
-    /*Options for metric verifier algorithm*/
-    std::string metric;
-    std::string metric_algo;
-    std::vector<unsigned int> lhs_indices;
-    std::vector<unsigned int> rhs_indices;
-    long double parameter = 0;
-    unsigned int q = 2;
-    bool dist_to_null_infinity = false;
+    std::string primitive;
 
     /*Options for algebraic constraints algorithm*/
     char bin_operation = '+';
-    double fuzziness = 0.15; 
+    double fuzziness = 0.15;
     double p_fuzz = 0.9;
     double weight = 0.05;
     size_t bumps_limit = 5;
-    size_t iterations_limit = 10; 
+    size_t iterations_limit = 10;
     std::string pairing_rule = "trivial";
 
-    std::string const algo_desc = "algorithm to use. Available algorithms:\n" +
-                                  EnumToAvailableValues<algos::Algo>() +
-                                  " for FD mining.";
-    std::string const task_desc = "type of dependency to mine. Available tasks:\n" +
-                                  EnumToAvailableValues<algos::AlgoMiningType>();
     std::string const separator_arg = std::string{onam::kSeparator} + ",s";
+    std::string const prim_desc = "algorithm to use for data profiling\n" +
+                                  EnumToAvailableValues<algos::PrimitiveType>() + " + [ac]";
+    constexpr auto help_opt = "help";
+    constexpr auto prim_opt = "primitive";
+    std::string const separator_opt = std::string(onam::kSeparator) + ",s";
 
     po::options_description info_options("Desbordante information options");
     info_options.add_options()
-        (onam::kHelp, "print the help message and exit")
+        (help_opt, "print the help message and exit")
         // --version, if needed, goes here too
         ;
 
     po::options_description general_options("General options");
     general_options.add_options()
-        (onam::kTask, po::value<std::string>(&task), task_desc.c_str())
-        (onam::kAlgorithm, po::value<std::string>(&algo), algo_desc.c_str())
-        (onam::kData, po::value<std::string>(&dataset), desc::kDData)
-        (separator_arg.data(), po::value<char>(&separator)->default_value(separator),
-                desc::kDSeparator)
-        (onam::kHasHeader, po::value<bool>(&has_header)->default_value(has_header),
-                desc::kDHasHeader)
-        (onam::kEqualNulls, po::value<bool>(&is_null_equal_null)->default_value(true),
-                desc::kDEqualNulls)
-        (onam::kThreads, po::value<ushort>(&threads)->default_value(threads),
-                desc::kDThreads)
-        ;
+            (prim_opt, po::value<std::string>(&primitive)->required(), prim_desc.c_str())
+            (onam::kData, po::value<std::string>()->required(), desc::kDData)
+            (separator_opt.c_str(), po::value<char>()->default_value(','), desc::kDSeparator)
+            (onam::kHasHeader, po::value<bool>()->default_value(true), desc::kDHasHeader)
+            (onam::kEqualNulls, po::value<bool>(), desc::kDEqualNulls)
+            (onam::kThreads, po::value<ushort>(), desc::kDThreads)
+            ;
 
     po::options_description typos_fd_options("Typo mining/FD options");
     typos_fd_options.add_options()
-        (onam::kError, po::value<double>(&error)->default_value(error), desc::kDError)
-        (onam::kMaximumLhs, po::value<unsigned int>(&max_lhs)->default_value(max_lhs),
-                desc::kDMaximumLhs)
-        (onam::kSeed, po::value<int>(&seed)->default_value(seed), desc::kDSeed)
-        ;
+            (onam::kError, po::value<double>(), desc::kDError)
+            (onam::kMaximumLhs, po::value<unsigned int>(), desc::kDMaximumLhs)
+            (onam::kSeed, po::value<int>(), desc::kDSeed)
+            ;
 
     po::options_description ar_options("AR options");
     ar_options.add_options()
-        (onam::kMinimumSupport, po::value<double>(&minsup), desc::kDMinimumSupport)
-        (onam::kMinimumConfidence, po::value<double>(&minconf), desc::kDMinimumConfidence)
-        (onam::kInputFormat, po::value<string>(&ar_input_format), desc::kDInputFormat)
-        ;
+            (onam::kMinimumSupport, po::value<double>(), desc::kDMinimumSupport)
+            (onam::kMinimumConfidence, po::value<double>(), desc::kDMinimumConfidence)
+            (onam::kInputFormat, po::value<string>(), desc::kDInputFormat)
+            ;
 
     po::options_description ar_singular_options("AR \"singular\" input format options");
     ar_singular_options.add_options()
-        (onam::kTIdColumnIndex, po::value<unsigned>(&tid_column_index)->default_value(0),
-                desc::kDTIdColumnIndex)
-        (onam::kItemColumnIndex, po::value<unsigned>(&item_column_index)->default_value(1),
-                desc::kDItemColumnIndex)
-        ;
+            (onam::kTIdColumnIndex, po::value<unsigned>(), desc::kDTIdColumnIndex)
+            (onam::kItemColumnIndex, po::value<unsigned>(), desc::kDItemColumnIndex)
+            ;
 
     po::options_description ar_tabular_options("AR \"tabular\" input format options");
     ar_tabular_options.add_options()
-        (onam::kFirstColumnTId, po::bool_switch(&has_transaction_id), desc::kDFirstColumnTId)
-        ;
+            (onam::kFirstColumnTId, po::bool_switch(), desc::kDFirstColumnTId)
+            ;
 
     ar_options.add(ar_singular_options).add(ar_tabular_options);
 
     po::options_description mfd_options("MFD options");
     mfd_options.add_options()
-        (onam::kMetric, po::value<std::string>(&metric), desc::kDMetric)
-        (onam::kMetricAlgorithm, po::value<std::string>(&metric_algo), desc::kDMetricAlgorithm)
-        (onam::kLhsIndices, po::value<std::vector<unsigned int>>(&lhs_indices)->multitoken(),
-                desc::kDLhsIndices)
-        (onam::kRhsIndices, po::value<std::vector<unsigned int>>(&rhs_indices)->multitoken(),
-                desc::kDRhsIndices)
-        (onam::kParameter, po::value<long double>(&parameter), desc::kDParameter)
-        (onam::kDistToNullIsInfinity, po::bool_switch(&dist_to_null_infinity),
-                desc::kDDistToNullIsInfinity)
-        ;
+            (onam::kMetric, po::value<algos::Metric>(), desc::kDMetric)
+            (onam::kMetricAlgorithm, po::value<algos::MetricAlgo>(), desc::kDMetricAlgorithm)
+            (onam::kLhsIndices, po::value<std::vector<unsigned int>>()->multitoken(),
+             desc::kDLhsIndices)
+            (onam::kRhsIndices, po::value<std::vector<unsigned int>>()->multitoken(),
+             desc::kDRhsIndices)
+            (onam::kParameter, po::value<long double>(), desc::kDParameter)
+            (onam::kDistToNullIsInfinity, po::bool_switch(), desc::kDDistToNullIsInfinity)
+            ;
 
     po::options_description cosine_options("Cosine metric options");
     cosine_options.add_options()
-        (onam::kQGramLength, po::value<unsigned int>(&q)->default_value(2), desc::kDQGramLength)
-        ;
+            (onam::kQGramLength, po::value<unsigned int>(), desc::kDQGramLength)
+            ;
 
     mfd_options.add(cosine_options);
 
@@ -212,92 +152,31 @@ int main(int argc, char const* argv[]) {
     po::variables_map vm;
     try {
         po::store(po::parse_command_line(argc, argv, all_options), vm);
-        po::notify(vm);
     } catch (po::error &e) {
         std::cout << e.what() << std::endl;
-        return 0;
+        return 1;
     }
-
-    if (vm.count(onam::kHelp))
+    if (vm.count(help_opt))
     {
         std::cout << all_options << std::endl;
         return 0;
     }
-
-    el::Loggers::configureFromGlobal("logging.conf");
-
-    std::transform(algo.begin(), algo.end(), algo.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-
-    if (task == "metric") {
-        auto remove_duplicates = [](std::vector<unsigned>& vec) {
-            if (vec.empty()) {
-                throw std::invalid_argument("Index vector should not be empty.");
-            }
-            std::sort(vec.begin(), vec.end());
-            vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
-        };
-        remove_duplicates(lhs_indices);
-        remove_duplicates(rhs_indices);
-        vm.at("rhs_indices").value() = rhs_indices;
-        vm.at("lhs_indices").value() = lhs_indices;
-    }
-
-    if (!CheckOptions(task, algo, metric, metric_algo, rhs_indices.size(), error)) {
-        std::cout << all_options << std::endl;
+    try {
+        po::notify(vm);
+    } catch (po::error &e) {
+        std::cout << e.what() << std::endl;
         return 1;
     }
 
-    if (task == "fd" || task == "typos") {
-        std::cout << "Input: algorithm \"" << algo
-                  << "\" with seed " << std::to_string(seed)
-                  << ", error \"" << std::to_string(error)
-                  << ", max_lhs \"" << std::to_string(max_lhs)
-                  << "\" and dataset \"" << dataset
-                  << "\" with separator \'" << separator
-                  << "\'. Header is " << (has_header ? "" : "not ") << "present. " << std::endl;
-    } else if (task == "ar") {
-        std::cout << "Input: algorithm \"" << algo
-                  << "\" with min. support threshold \"" << std::to_string(minsup)
-                  << "\", min. confidence threshold \"" << std::to_string(minconf)
-                  << "\" and dataset \"" << dataset
-                  << "\". Input type is \"" << ar_input_format
-                  << "\" with separator \'" << separator
-                  << "\'. Header is " << (has_header ? "" : "not ") << "present. " << std::endl;
-    } else if (task == "metric") {
-        algo = "metric";
-        auto get_str = [](std::vector<unsigned> const& vec) {
-            std::stringstream stream;
-            std::copy(vec.begin(), vec.end(), std::ostream_iterator<int>(stream, " "));
-            string lhs_indices_str = stream.str();
-            boost::trim_right(lhs_indices_str);
-            return lhs_indices_str;
-        };
-        std::cout << "Input metric \"" << metric;
-        if (metric == "cosine") std::cout << "\" with q \"" << q;
-        std::cout << "\" with parameter \"" << parameter
-                  << "\" with LHS indices \"" << get_str(lhs_indices)
-                  << "\" with RHS indices \"" << get_str(rhs_indices)
-                  << "\" and dataset \"" << dataset
-                  << "\" with separator \'" << separator
-                  << "\'. Header is " << (has_header ? "" : "not ") << "present. " << std::endl;
-    } else if (task == "ac") {
-        std::cout << "Input: algorithm \"" << algo
-                  << "\" with binary operation \"" << bin_operation
-                  << "\", fuzziness \"" << std::to_string(fuzziness)
-                  << "\", fuzziness probability \"" << std::to_string(p_fuzz)
-                  << "\", weight \"" << std::to_string(weight)
-                  << "\", bumps limit \"" << std::to_string(bumps_limit)
-                  << "\", iterations limit \"" << std::to_string(iterations_limit)
-                  << "\", pairing rule \"" << pairing_rule
-                  << "\" and dataset \"" << dataset
-                  << "\" with separator \'" << separator
-                  << "\'. Header is " << (has_header ? "" : "not ") << "present. " << std::endl;
+    el::Loggers::configureFromGlobal("logging.conf");
+
+    std::unique_ptr<algos::Primitive> algorithm_instance;
+    try {
+        algorithm_instance = algos::CreatePrimitive(primitive, vm);
+    } catch (std::exception& e) {
+        std::cout << e.what() << std::endl;
+        return 1;
     }
-
-    std::unique_ptr<algos::Primitive> algorithm_instance =
-        algos::CreateAlgorithmInstance(task, algo, vm);
-
     try {
         unsigned long long elapsed_time = algorithm_instance->Execute();
         std::cout << "> ELAPSED TIME: " << elapsed_time << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,8 @@
 #include <boost/program_options.hpp>
 #include <easylogging++.h>
 
-#include "algo_factory.h"
-#include "program_option_strings.h"
+#include "algorithms/algo_factory.h"
+#include "algorithms/options/names.h"
 
 namespace po = boost::program_options;
 namespace posr = program_option_strings;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,7 @@ int main(int argc, char const* argv[]) {
         EnumToAvailableValues<algos::Metric>();
     std::string const metric_algo_desc = "MFD algorithm to use. Available algorithms:\n" +
         EnumToAvailableValues<algos::MetricAlgo>();
+    std::string const separator_arg = std::string{onam::kSeparator} + ",s";
 
     po::options_description info_options("Desbordante information options");
     info_options.add_options()
@@ -141,7 +142,7 @@ int main(int argc, char const* argv[]) {
         (onam::kAlgorithm, po::value<std::string>(&algo), algo_desc.c_str())
         (onam::kData, po::value<std::string>(&dataset),
          "path to CSV file, relative to ./input_data")
-        (onam::kSeparatorLibArg, po::value<char>(&separator)->default_value(separator),
+        (separator_arg.data(), po::value<char>(&separator)->default_value(separator),
          "CSV separator")
         (onam::kHasHeader, po::value<bool>(&has_header)->default_value(has_header),
          "CSV header presence flag [true|false]")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@
 #include "algorithms/options/names.h"
 
 namespace po = boost::program_options;
-namespace posr = program_option_strings;
+namespace onam = algos::config::names;
 
 INITIALIZE_EASYLOGGINGPP
 
@@ -131,57 +131,57 @@ int main(int argc, char const* argv[]) {
 
     po::options_description info_options("Desbordante information options");
     info_options.add_options()
-        (posr::kHelp, "print the help message and exit")
+        (onam::kHelp, "print the help message and exit")
         // --version, if needed, goes here too
         ;
 
     po::options_description general_options("General options");
     general_options.add_options()
-        (posr::kTask, po::value<std::string>(&task), task_desc.c_str())
-        (posr::kAlgorithm, po::value<std::string>(&algo), algo_desc.c_str())
-        (posr::kData, po::value<std::string>(&dataset),
-            "path to CSV file, relative to ./input_data")
-        (posr::kSeparatorLibArg, po::value<char>(&separator)->default_value(separator),
-            "CSV separator")
-        (posr::kHasHeader, po::value<bool>(&has_header)->default_value(has_header),
+        (onam::kTask, po::value<std::string>(&task), task_desc.c_str())
+        (onam::kAlgorithm, po::value<std::string>(&algo), algo_desc.c_str())
+        (onam::kData, po::value<std::string>(&dataset),
+         "path to CSV file, relative to ./input_data")
+        (onam::kSeparatorLibArg, po::value<char>(&separator)->default_value(separator),
+         "CSV separator")
+        (onam::kHasHeader, po::value<bool>(&has_header)->default_value(has_header),
          "CSV header presence flag [true|false]")
-        (posr::kEqualNulls, po::value<bool>(&is_null_equal_null)->default_value(true),
+        (onam::kEqualNulls, po::value<bool>(&is_null_equal_null)->default_value(true),
          "specify whether two NULLs should be considered equal")
-        (posr::kThreads, po::value<ushort>(&threads)->default_value(threads),
+        (onam::kThreads, po::value<ushort>(&threads)->default_value(threads),
          "number of threads to use. If 0, then as many threads are used as "
          "the hardware can handle concurrently.")
         ;
 
     po::options_description typos_fd_options("Typo mining/FD options");
     typos_fd_options.add_options()
-        (posr::kError, po::value<double>(&error)->default_value(error),
+        (onam::kError, po::value<double>(&error)->default_value(error),
          "error value for AFD algorithms")
-        (posr::kMaximumLhs, po::value<unsigned int>(&max_lhs)->default_value(max_lhs),
+        (onam::kMaximumLhs, po::value<unsigned int>(&max_lhs)->default_value(max_lhs),
          "max considered LHS size")
-        (posr::kSeed, po::value<int>(&seed)->default_value(seed), "RNG seed")
+        (onam::kSeed, po::value<int>(&seed)->default_value(seed), "RNG seed")
         ;
 
     po::options_description ar_options("AR options");
     ar_options.add_options()
-        (posr::kMinimumSupport, po::value<double>(&minsup),
-            "minimum support value (between 0 and 1)")
-        (posr::kMinimumConfidence, po::value<double>(&minconf),
-            "minimum confidence value (between 0 and 1)")
-        (posr::kInputFormat, po::value<string>(&ar_input_format),
+        (onam::kMinimumSupport, po::value<double>(&minsup),
+         "minimum support value (between 0 and 1)")
+        (onam::kMinimumConfidence, po::value<double>(&minconf),
+         "minimum confidence value (between 0 and 1)")
+        (onam::kInputFormat, po::value<string>(&ar_input_format),
          "format of the input dataset. [singular|tabular] for AR mining")
         ;
 
     po::options_description ar_singular_options("AR \"singular\" input format options");
     ar_singular_options.add_options()
-        (posr::kTIdColumnIndex, po::value<unsigned>(&tid_column_index)->default_value(0),
+        (onam::kTIdColumnIndex, po::value<unsigned>(&tid_column_index)->default_value(0),
          "index of the column where a TID is stored")
-        (posr::kItemColumnIndex, po::value<unsigned>(&item_column_index)->default_value(1),
+        (onam::kItemColumnIndex, po::value<unsigned>(&item_column_index)->default_value(1),
          "index of the column where an item name is stored")
         ;
 
     po::options_description ar_tabular_options("AR \"tabular\" input format options");
     ar_tabular_options.add_options()
-        (posr::kFirstColumnTId, po::bool_switch(&has_transaction_id),
+        (onam::kFirstColumnTId, po::bool_switch(&has_transaction_id),
          "indicates that the first column contains the transaction IDs")
         ;
 
@@ -189,20 +189,20 @@ int main(int argc, char const* argv[]) {
 
     po::options_description mfd_options("MFD options");
     mfd_options.add_options()
-        (posr::kMetric, po::value<std::string>(&metric), metric_desc.c_str())
-        (posr::kMetricAlgorithm, po::value<std::string>(&metric_algo), metric_algo_desc.c_str())
-        (posr::kLhsIndices, po::value<std::vector<unsigned int>>(&lhs_indices)->multitoken(),
+        (onam::kMetric, po::value<std::string>(&metric), metric_desc.c_str())
+        (onam::kMetricAlgorithm, po::value<std::string>(&metric_algo), metric_algo_desc.c_str())
+        (onam::kLhsIndices, po::value<std::vector<unsigned int>>(&lhs_indices)->multitoken(),
          "LHS column indices for metric FD verification")
-        (posr::kRhsIndices, po::value<std::vector<unsigned int>>(&rhs_indices)->multitoken(),
+        (onam::kRhsIndices, po::value<std::vector<unsigned int>>(&rhs_indices)->multitoken(),
          "RHS column indices for metric FD verification")
-        (posr::kParameter, po::value<long double>(&parameter), "metric FD parameter")
-        (posr::kDistToNullIsInfinity, po::bool_switch(&dist_to_null_infinity),
+        (onam::kParameter, po::value<long double>(&parameter), "metric FD parameter")
+        (onam::kDistToNullIsInfinity, po::bool_switch(&dist_to_null_infinity),
          "specify whether distance to NULL value is infinity (otherwise it is 0)")
         ;
 
     po::options_description cosine_options("Cosine metric options");
     cosine_options.add_options()
-        (posr::kQGramLength, po::value<unsigned int>(&q)->default_value(2),
+        (onam::kQGramLength, po::value<unsigned int>(&q)->default_value(2),
          "q-gram length for cosine metric")
         ;
 
@@ -210,21 +210,21 @@ int main(int argc, char const* argv[]) {
 
     po::options_description ac_options("AC options");
     ac_options.add_options()
-        (posr::kBinaryOperation, po::value<char>(&bin_operation)->default_value(bin_operation),
+        (onam::kBinaryOperation, po::value<char>(&bin_operation)->default_value(bin_operation),
          "one of availible operations: /, *, +, - ")
-        (posr::kFuzziness, po::value<double>(&fuzziness)->default_value(0.15),
+        (onam::kFuzziness, po::value<double>(&fuzziness)->default_value(0.15),
          "fraction of exceptional records")
-        (posr::kFuzzinessProbability, po::value<double>(&p_fuzz)->default_value(p_fuzz),
+        (onam::kFuzzinessProbability, po::value<double>(&p_fuzz)->default_value(p_fuzz),
          "probability, the fraction of exceptional records that lie outside the "
          "bump intervals is at most Fuzziness")
-        (posr::kWeight, po::value<double>(&weight)->default_value(weight),
+        (onam::kWeight, po::value<double>(&weight)->default_value(weight),
          "value between 0 and 1. Closer to 0 - many short intervals. "
          "Closer to 1 - small number of long intervals")
-        (posr::kBumpsLimit, po::value<size_t>(&bumps_limit)->default_value(bumps_limit),
+        (onam::kBumpsLimit, po::value<size_t>(&bumps_limit)->default_value(bumps_limit),
          "max considered intervals amount. Pass 0 to remove limit")
-        (posr::kIterationsLimit, po::value<size_t>(&iterations_limit)->default_value(iterations_limit),
+        (onam::kIterationsLimit, po::value<size_t>(&iterations_limit)->default_value(iterations_limit),
          "limit for iterations of sampling")
-        (posr::kPairingRule, po::value<std::string>(&pairing_rule)->default_value(pairing_rule),
+        (onam::kPairingRule, po::value<std::string>(&pairing_rule)->default_value(pairing_rule),
          "one of available pairing rules: trivial")
         ;
 
@@ -241,7 +241,7 @@ int main(int argc, char const* argv[]) {
         return 0;
     }
 
-    if (vm.count(posr::kHelp))
+    if (vm.count(onam::kHelp))
     {
         std::cout << all_options << std::endl;
         return 0;

--- a/src/model/transactional_data.cpp
+++ b/src/model/transactional_data.cpp
@@ -6,18 +6,6 @@
 
 namespace model {
 
-std::unique_ptr<TransactionalData> TransactionalData::CreateFrom(IDatasetStream& data_stream,
-                                                                 InputFormat const& input_type) {
-    if (typeid(input_type) == typeid(Singular)) {
-        return TransactionalData::CreateFromSingular(data_stream, input_type.tid_column_index(),
-                                                     input_type.item_column_index());
-    } else if (typeid(input_type) == typeid(Tabular)) {
-        return TransactionalData::CreateFromTabular(data_stream, input_type.tid_presence());
-    } else {
-        throw std::logic_error("This input type is not maintained yet");
-    }
-}
-
 std::unique_ptr<TransactionalData> TransactionalData::CreateFromSingular(
         IDatasetStream& data_stream,
         size_t tid_col_index,

--- a/src/model/transactional_data.h
+++ b/src/model/transactional_data.h
@@ -16,13 +16,6 @@ private:
     std::vector<std::string> item_universe_;
     std::unordered_map<size_t, Itemset> transactions_;
 
-    static std::unique_ptr<TransactionalData> CreateFromSingular(IDatasetStream& data_stream,
-                                                                 size_t tid_col_index = 0,
-                                                                 size_t item_col_index = 1);
-
-    static std::unique_ptr<TransactionalData> CreateFromTabular(IDatasetStream& data_stream,
-                                                                bool has_tid);
-
     TransactionalData(std::vector<std::string> item_universe,
                       std::unordered_map<size_t, Itemset> transactions)
         : item_universe_(std::move(item_universe)), transactions_(std::move(transactions)) {}
@@ -44,8 +37,12 @@ public:
     size_t GetUniverseSize() const noexcept { return item_universe_.size(); }
     size_t GetNumTransactions() const noexcept { return transactions_.size(); }
 
-    static std::unique_ptr<TransactionalData> CreateFrom(IDatasetStream& data_stream,
-                                                         InputFormat const& input_type);
+    static std::unique_ptr<TransactionalData> CreateFromSingular(IDatasetStream& data_stream,
+                                                                 size_t tid_col_index = 0,
+                                                                 size_t item_col_index = 1);
+
+    static std::unique_ptr<TransactionalData> CreateFromTabular(IDatasetStream& data_stream,
+                                                                bool has_tid);
 };
 
 }  // namespace model

--- a/src/model/typed_column_data.cpp
+++ b/src/model/typed_column_data.cpp
@@ -1,4 +1,5 @@
-#include "typed_column_data.h"
+#include "model/column_layout_typed_relation_data.h"
+#include "model/typed_column_data.h"
 
 #include "create_type.h"
 
@@ -167,6 +168,15 @@ TypedColumnData TypedColumnDataFactory::CreateFrom() {
     type_map.insert(std::move(empty_node));
 
     return CreateFromTypeMap(CreateType(type_id, is_null_equal_null_), std::move(type_map));
+}
+
+std::vector<TypedColumnData> CreateTypedColumnData(IDatasetStream& dataset_stream,
+                                                   bool is_null_equal_null) {
+    std::unique_ptr<model::ColumnLayoutTypedRelationData> relation_data =
+            model::ColumnLayoutTypedRelationData::CreateFrom(dataset_stream,
+                                                             is_null_equal_null, -1, -1);
+    std::vector<model::TypedColumnData> col_data = std::move(relation_data->GetColumnData());
+    return col_data;
 }
 
 }  // namespace model

--- a/src/model/typed_column_data.h
+++ b/src/model/typed_column_data.h
@@ -4,9 +4,10 @@
 #include <string>
 #include <vector>
 
-#include "abstract_column_data.h"
-#include "relation_data.h"
-#include "types/types.h"
+#include "model/abstract_column_data.h"
+#include "model/idataset_stream.h"
+#include "model/relation_data.h"
+#include "model/types/types.h"
 
 namespace model {
 
@@ -193,5 +194,8 @@ public:
         return f.CreateFrom();
     }
 };
+
+std::vector<TypedColumnData> CreateTypedColumnData(IDatasetStream& dataset_stream,
+                                                   bool is_null_equal_null);
 
 }  // namespace model

--- a/src/util/agree_set_factory.cpp
+++ b/src/util/agree_set_factory.cpp
@@ -95,8 +95,9 @@ AgreeSetFactory::SetOfAgreeSets AgreeSetFactory::GenAsUsingVectorOfIdSets() cons
     if (!identifier_sets.empty()) {
         size_t const size = identifier_sets.size();
         size_t const pairs_num = (size_t)(size * (size - 1) / 2);
-        double const percent_per_idset = (pairs_num == 0) ? FDAlgorithm::kTotalProgressPercent :
-                                         FDAlgorithm::kTotalProgressPercent / pairs_num;
+        double const percent_per_idset = (pairs_num == 0)
+                ? algos::FDAlgorithm::kTotalProgressPercent
+                : algos::FDAlgorithm::kTotalProgressPercent / pairs_num;
         auto back_it = std::prev(identifier_sets.end());
         for (auto p = identifier_sets.begin(); p != back_it; ++p) {
             for (auto q = std::next(p); q != identifier_sets.end(); ++q) {
@@ -134,8 +135,9 @@ AgreeSetFactory::SetOfAgreeSets AgreeSetFactory::GenAsUsingMapOfIdSets() const {
     // compute agree sets using identifier sets
     // metanome approach (using map of identifier sets)
     double const percent_per_cluster =
-        max_representation.empty() ? FDAlgorithm::kTotalProgressPercent
-                                   : FDAlgorithm::kTotalProgressPercent / max_representation.size();
+        max_representation.empty()
+        ? algos::FDAlgorithm::kTotalProgressPercent
+        : algos::FDAlgorithm::kTotalProgressPercent / max_representation.size();
 
     if (config_.threads_num > 1) {
         /* Not as fast and simple as it can be, need to use concurrent unordered_set.

--- a/src/util/agree_set_factory.h
+++ b/src/util/agree_set_factory.h
@@ -139,7 +139,7 @@ public:
 
     explicit AgreeSetFactory(ColumnLayoutRelationData const* const rel,
                              Configuration const& c = Configuration(),
-                             FDAlgorithm* algo = nullptr)
+                             algos::FDAlgorithm* algo = nullptr)
         : relation_(rel), config_(c), algo_(algo) {}
 
     ColumnLayoutRelationData const* GetRelation() const { return relation_; }
@@ -193,7 +193,7 @@ private:
     ColumnLayoutRelationData const* const relation_;
 
     Configuration config_;
-    FDAlgorithm* algo_;
+    algos::FDAlgorithm* algo_;
 };
 
 } // namespace util

--- a/tests/test_algo_interfaces.cpp
+++ b/tests/test_algo_interfaces.cpp
@@ -28,14 +28,14 @@ class KeysTest : public ::testing::TestWithParam<KeysTestParams> {};
 
 template<typename AlgoInterface>
 static inline void GetKeysTestImpl(KeysTestParams const& p) {
-    namespace posr = program_option_strings;
+    namespace onam = algos::config::names;
 
     auto const path = fs::current_path() / "input_data" / p.dataset;
     std::vector<unsigned int> actual;
     FDAlgorithm::Config c{.data = path,
                           .separator = p.sep,
                           .has_header = p.has_header,
-                          .special_params = {{posr::kSeed, 0}, {posr::kError, 0.0}}};
+                          .special_params = {{onam::kSeed, 0}, {onam::kError, 0.0}}};
     algos::Pyro pyro(c);
 
     pyro.Execute();

--- a/tests/test_algo_interfaces.cpp
+++ b/tests/test_algo_interfaces.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "pyro.h"
-#include "program_option_strings.h"
+#include "algorithms/pyro.h"
+#include "algorithms/options/names.h"
 
 namespace tests {
 

--- a/tests/test_algo_interfaces.cpp
+++ b/tests/test_algo_interfaces.cpp
@@ -5,12 +5,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "algorithms/algo_factory.h"
 #include "algorithms/pyro.h"
 #include "algorithms/options/names.h"
 
 namespace tests {
 
 using ::testing::ContainerEq;
+using algos::FDAlgorithm, algos::PliBasedFDAlgorithm, algos::StdParamsMap;
 
 namespace fs = std::filesystem;
 
@@ -30,13 +32,17 @@ template<typename AlgoInterface>
 static inline void GetKeysTestImpl(KeysTestParams const& p) {
     namespace onam = algos::config::names;
 
-    auto const path = fs::current_path() / "input_data" / p.dataset;
+    std::string const path{fs::current_path() / "input_data" / p.dataset};
     std::vector<unsigned int> actual;
-    FDAlgorithm::Config c{.data = path,
-                          .separator = p.sep,
-                          .has_header = p.has_header,
-                          .special_params = {{onam::kSeed, 0}, {onam::kError, 0.0}}};
-    algos::Pyro pyro(c);
+    StdParamsMap params_map{
+            {onam::kData, path},
+            {onam::kSeparator, p.sep},
+            {onam::kHasHeader, p.has_header},
+            {onam::kSeed, decltype(Configuration::seed){0}},
+            {onam::kError, algos::config::ErrorType{0.0}}
+    };
+    auto pyro_ptr = algos::CreateAndLoadPrimitive<algos::Pyro>(params_map);
+    auto &pyro = *pyro_ptr;
 
     pyro.Execute();
 

--- a/tests/test_algorithm.cpp
+++ b/tests/test_algorithm.cpp
@@ -6,16 +6,16 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "algorithms/depminer/depminer.h"
+#include "algorithms/dfd/dfd.h"
+#include "algorithms/fastfds.h"
+#include "algorithms/fdep/fdep.h"
+#include "algorithms/fun.h"
+#include "algorithms/hyfd/hyfd.h"
+#include "algorithms/pyro.h"
+#include "algorithms/tane.h"
 #include "datasets.h"
-#include "depminer.h"
-#include "dfd.h"
-#include "fastfds.h"
-#include "fdep/fdep.h"
-#include "fun.h"
-#include "hyfd/hyfd.h"
-#include "pyro.h"
-#include "relational_schema.h"
-#include "tane.h"
+#include "model/relational_schema.h"
 #include "testing_utils.h"
 
 using ::testing::ContainerEq, ::testing::Eq;
@@ -67,8 +67,9 @@ TYPED_TEST_SUITE_P(AlgorithmTest);
 
 TYPED_TEST_P(AlgorithmTest, ThrowsOnEmpty) {
     auto const path = fs::current_path() / "input_data" / "TestEmpty.csv";
-    auto algorithm = TestFixture::CreateAlgorithmInstance(path, ',', true);
-    ASSERT_THROW(algorithm->Execute(), std::runtime_error);
+    auto primitive = TestFixture::CreateAndConfToFit();
+    auto parser = TestFixture::MakeCsvParser(path, ',', true);
+    ASSERT_THROW(primitive->Fit(parser), std::runtime_error);
 }
 
 TYPED_TEST_P(AlgorithmTest, ReturnsEmptyOnSingleNonKey) {

--- a/tests/test_fd_mine.cpp
+++ b/tests/test_fd_mine.cpp
@@ -122,7 +122,7 @@ void MinimizeFDs(std::list<FD>& fd_collection) {
 }
 
 TEST_F(AlgorithmTest, FD_Mine_ReturnsSameAsPyro) {
-    namespace posr = program_option_strings;
+    namespace onam = algos::config::names;
 
     auto path = std::filesystem::current_path() / "input_data";
 
@@ -140,7 +140,7 @@ TEST_F(AlgorithmTest, FD_Mine_ReturnsSameAsPyro) {
             FDAlgorithm::Config c{.data = path / LightDatasets::DatasetName(i),
                                   .separator = LightDatasets::Separator(i),
                                   .has_header = LightDatasets::HasHeader(i),
-                                  .special_params = {{posr::kSeed, 0}, {posr::kError, 0.0}}};
+                                  .special_params = {{onam::kSeed, 0}, {onam::kError, 0.0}}};
             auto pyro = algos::Pyro(c);
 
             algorithm->Execute();

--- a/tests/test_fd_mine.cpp
+++ b/tests/test_fd_mine.cpp
@@ -8,10 +8,10 @@
 
 #include "algorithms/fd_mine.h"
 #include "algorithms/tane.h"
+#include "algorithms/options/names.h"
+#include "algorithms/pyro.h"
 #include "datasets.h"
-#include "program_option_strings.h"
-#include "pyro.h"
-#include "relational_schema.h"
+#include "model/relational_schema.h"
 
 using ::testing::ContainerEq, ::testing::Eq;
 

--- a/tests/test_metric_verifier.cpp
+++ b/tests/test_metric_verifier.cpp
@@ -5,9 +5,9 @@
 
 #include <gtest/gtest.h>
 
-#include "algo_factory.h"
-#include "metric_verifier.h"
-#include "program_option_strings.h"
+#include "algorithms/algo_factory.h"
+#include "algorithms/metric_verifier.h"
+#include "algorithms/options/names.h"
 
 namespace tests {
 namespace posr = program_option_strings;

--- a/tests/test_metric_verifier.cpp
+++ b/tests/test_metric_verifier.cpp
@@ -10,7 +10,7 @@
 #include "algorithms/options/names.h"
 
 namespace tests {
-namespace posr = program_option_strings;
+namespace onam = algos::config::names;
 
 struct MetricVerifyingParams {
     algos::StdParamsMap params;
@@ -27,17 +27,17 @@ struct MetricVerifyingParams {
                           bool const dist_to_null_infinity = false,
                           bool const expected = true,
                           unsigned const q = 2)
-        : params({{posr::kParameter, min_parameter},
-                  {posr::kLhsIndices, std::move(lhs_indices)},
-                  {posr::kRhsIndices, std::move(rhs_indices)},
-                  {posr::kData, dataset},
-                  {posr::kSeparatorConfig, separator},
-                  {posr::kHasHeader, has_header},
-                  {posr::kEqualNulls, true},
-                  {posr::kMetric, metric},
-                  {posr::kQGramLength, q},
-                  {posr::kMetricAlgorithm, algo},
-                  {posr::kDistToNullIsInfinity, dist_to_null_infinity}}),
+        : params({{onam::kParameter,            min_parameter},
+                  {onam::kLhsIndices,           std::move(lhs_indices)},
+                  {onam::kRhsIndices,           std::move(rhs_indices)},
+                  {onam::kData,                 dataset},
+                  {onam::kSeparatorConfig,      separator},
+                  {onam::kHasHeader,            has_header},
+                  {onam::kEqualNulls,           true},
+                  {onam::kMetric,               metric},
+                  {onam::kQGramLength,          q},
+                  {onam::kMetricAlgorithm,      algo},
+                  {onam::kDistToNullIsInfinity, dist_to_null_infinity}}),
           expected(expected) {}
 };
 
@@ -64,7 +64,7 @@ TEST_P(TestMetricVerifying, DefaultTest) {
     }
     ASSERT_TRUE(GetResult(*verifier));
 
-    auto new_parameter = boost::any_cast<long double>(params.at(posr::kParameter));
+    auto new_parameter = boost::any_cast<long double>(params.at(onam::kParameter));
     new_parameter -= 1e-4;
     if (new_parameter < 0) return;
     verifier->SetParameter(new_parameter);

--- a/tests/test_metric_verifier.cpp
+++ b/tests/test_metric_verifier.cpp
@@ -31,7 +31,7 @@ struct MetricVerifyingParams {
                   {onam::kLhsIndices,           std::move(lhs_indices)},
                   {onam::kRhsIndices,           std::move(rhs_indices)},
                   {onam::kData,                 dataset},
-                  {onam::kSeparatorConfig,      separator},
+                  {onam::kSeparator,            separator},
                   {onam::kHasHeader,            has_header},
                   {onam::kEqualNulls,           true},
                   {onam::kMetric,               metric},

--- a/tests/test_typo_miner.cpp
+++ b/tests/test_typo_miner.cpp
@@ -5,9 +5,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "algo_factory.h"
-#include "typo_miner.h"
-#include "program_option_strings.h"
+#include "algorithms/algo_factory.h"
+#include "algorithms/typo_miner.h"
+#include "algorithms/options/names.h"
 
 namespace tests {
 namespace posr = program_option_strings;

--- a/tests/test_typo_miner.cpp
+++ b/tests/test_typo_miner.cpp
@@ -18,14 +18,14 @@ struct TestingParam {
     TestingParam(std::string const& dataset,
                  char const separator, bool const has_header, bool const is_null_equal_null,
                  unsigned const max_lhs, double const error, ushort const threads)
-        : params({{onam::kData,            dataset},
-                  {onam::kSeparatorConfig, separator},
-                  {onam::kHasHeader,       has_header},
-                  {onam::kEqualNulls,      is_null_equal_null},
-                  {onam::kMaximumLhs,      max_lhs},
-                  {onam::kError,           error},
-                  {onam::kThreads,         threads},
-                  {onam::kSeed,            0}}) {}
+        : params({{onam::kData,       dataset},
+                  {onam::kSeparator,  separator},
+                  {onam::kHasHeader,  has_header},
+                  {onam::kEqualNulls, is_null_equal_null},
+                  {onam::kMaximumLhs, max_lhs},
+                  {onam::kError,      error},
+                  {onam::kThreads,    threads},
+                  {onam::kSeed,       0}}) {}
 };
 
 /* FD represented as vector where all elements except last are lhs indices and

--- a/tests/test_typo_miner.cpp
+++ b/tests/test_typo_miner.cpp
@@ -10,7 +10,7 @@
 #include "algorithms/options/names.h"
 
 namespace tests {
-namespace posr = program_option_strings;
+namespace onam = algos::config::names;
 
 struct TestingParam {
     algos::StdParamsMap params;
@@ -18,14 +18,14 @@ struct TestingParam {
     TestingParam(std::string const& dataset,
                  char const separator, bool const has_header, bool const is_null_equal_null,
                  unsigned const max_lhs, double const error, ushort const threads)
-        : params({{posr::kData, dataset},
-                  {posr::kSeparatorConfig, separator},
-                  {posr::kHasHeader, has_header},
-                  {posr::kEqualNulls, is_null_equal_null},
-                  {posr::kMaximumLhs, max_lhs},
-                  {posr::kError, error},
-                  {posr::kThreads, threads},
-                  {posr::kSeed, 0}}) {}
+        : params({{onam::kData,            dataset},
+                  {onam::kSeparatorConfig, separator},
+                  {onam::kHasHeader,       has_header},
+                  {onam::kEqualNulls,      is_null_equal_null},
+                  {onam::kMaximumLhs,      max_lhs},
+                  {onam::kError,           error},
+                  {onam::kThreads,         threads},
+                  {onam::kSeed,            0}}) {}
 };
 
 /* FD represented as vector where all elements except last are lhs indices and

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -14,11 +14,11 @@ class AlgorithmTest : public LightDatasets, public HeavyDatasets, public ::testi
 protected:
     std::unique_ptr<FDAlgorithm> CreateAlgorithmInstance(
         std::filesystem::path const& path, char separator = ',', bool has_header = true) {
-        namespace posr = program_option_strings;
+        namespace onam = algos::config::names;
 
         FDAlgorithm::Config c{ .data = path, .separator = separator, .has_header = has_header };
-        c.special_params[posr::kError] = 0.0;
-        c.special_params[posr::kSeed] = 0;
+        c.special_params[onam::kError] = 0.0;
+        c.special_params[onam::kSeed] = 0;
         return std::make_unique<T>(c);
     }
 };

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -7,7 +7,7 @@
 
 #include <filesystem>
 
-#include "program_option_strings.h"
+#include "algorithms/options/names.h"
 
 template <typename T>
 class AlgorithmTest : public LightDatasets, public HeavyDatasets, public ::testing::Test {


### PR DESCRIPTION
Implementing Python bindings the way we want sensibly is impossible with the current method of configuration. This simplifies the way primitives are configured.