### PR TITLE
Update googletest

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -81,7 +81,7 @@ jobs:
         mkdir -p lib
         sudo chown -R $USER lib
         cd lib
-        git clone https://github.com/google/googletest/ --branch release-1.10.0
+        git clone https://github.com/google/googletest/ --branch release-1.12.1
       if: steps.cache-googletest.outputs.cache-hit != 'true'
     - name: Download easyloggingpp
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -87,7 +87,7 @@ jobs:
         mkdir -p lib
         sudo chown -R $USER lib
         cd lib
-        git clone https://github.com/google/googletest/ --branch release-1.10.0
+        git clone https://github.com/google/googletest/ --branch release-1.12.1
       if: steps.cache-googletest.outputs.cache-hit != 'true'
     - name: Download easyloggingpp
       run: |

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 mkdir lib
 cd lib
-git clone https://github.com/google/googletest/ --branch release-1.10.0
+git clone https://github.com/google/googletest/ --branch release-1.12.1
 git clone https://github.com/amrayn/easyloggingpp/ --branch v9.97.0
 git clone https://github.com/aantron/better-enums.git --branch 0.11.3
 git clone https://github.com/pybind/pybind11.git --branch v2.10


### PR DESCRIPTION
The old version did not build with `cmake` (as opposed to `make`). This allows Desbordante to be built using default CLion configuration.