### PR TITLE
Add 'help', 'tests', 'jobs' and 'pybind' options for build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,20 @@
 cmake_minimum_required(VERSION 3.10)
 project(Desbordante)
 
-option(ENABLE_PYBIND_COMPILE "Build the python bindings" ON)
-option(ENABLE_TESTS_COMPILE "Build tests and unpack datasets" ON)
+option(COMPILE_PYBIND "Build the python bindings" OFF)
+option(COMPILE_TESTS "Build tests" ON)
+option(UNPACK_DATASETS "Unpack datasets" ON)
+option(ASAN "Enable sanitizer" ON)
 
 # By default select Debug build
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif(NOT CMAKE_BUILD_TYPE)
+
+if (ASAN AND COMPILE_PYBIND)
+    message(WARNING "Disabling ASAN with python bindings")
+    set(ASAN OFF)
+endif()
 
 # compiler and platform-dependent settings
 set(CMAKE_CXX_STANDARD 17)
@@ -20,8 +27,11 @@ if (MSVC)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE  "${CMAKE_BINARY_DIR}/target")
 else()
     # -DELPP_THREAD_SAFE -- for easylogging++ thread safety
-    add_compile_options("$<$<CONFIG:Debug>:-O0;-DELPP_THREAD_SAFE;-g;-Wall;-Wextra;-Werror;-fno-omit-frame-pointer;-fsanitize=address>")
-    add_link_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+    add_compile_options("$<$<CONFIG:Debug>:-O0;-DELPP_THREAD_SAFE;-g;-Wall;-Wextra;-Werror;-fno-omit-frame-pointer>")
+    if (ASAN)
+        add_compile_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+        add_link_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+    endif()
     add_compile_options("$<$<CONFIG:Release>:-O3;-DELPP_THREAD_SAFE>")
 endif()
 
@@ -54,10 +64,10 @@ include_directories(
 include_directories(SYSTEM "lib/easyloggingpp/src" "lib/better-enums/")
 
 # adding submodules
-if (ENABLE_TESTS_COMPILE)
+if (COMPILE_TESTS)
     add_subdirectory("lib/googletest")
 endif()
-if (ENABLE_PYBIND_COMPILE)
+if (COMPILE_PYBIND)
     add_subdirectory("lib/pybind11")
 endif()
 
@@ -69,12 +79,14 @@ set( CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_COPY} )
 
 add_subdirectory("src")
 
-if (ENABLE_TESTS_COMPILE)
+if (COMPILE_TESTS)
     add_subdirectory("tests")
+endif()
+if (UNPACK_DATASETS)
     add_subdirectory("datasets")
 endif()
 add_subdirectory("cfg")
 
-if (ENABLE_PYBIND_COMPILE)
+if (COMPILE_PYBIND)
     add_subdirectory("python_bindings")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(Desbordante)
 
+option(ENABLE_PYBIND_COMPILE "Build the python bindings" ON)
+option(ENABLE_TESTS_COMPILE "Build tests and unpack datasets" ON)
+
 # By default select Debug build
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
@@ -42,7 +45,6 @@ include_directories(
     "src/util"
     "src/parser"
     "src/parser/json"
-    "src/tests"
     "src/core"
     "src/caching"
     "src/logging"
@@ -52,8 +54,12 @@ include_directories(
 include_directories(SYSTEM "lib/easyloggingpp/src" "lib/better-enums/")
 
 # adding submodules
-add_subdirectory("lib/googletest")
-add_subdirectory("lib/pybind11")
+if (ENABLE_TESTS_COMPILE)
+    add_subdirectory("lib/googletest")
+endif()
+if (ENABLE_PYBIND_COMPILE)
+    add_subdirectory("lib/pybind11")
+endif()
 
 set( CMAKE_BUILD_TYPE_COPY "${CMAKE_BUILD_TYPE}" )
 set( CMAKE_BUILD_TYPE "Release" )
@@ -62,9 +68,13 @@ add_subdirectory("lib/easyloggingpp")
 set( CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_COPY} )
 
 add_subdirectory("src")
-add_subdirectory("tests")
 
-add_subdirectory("datasets")
+if (ENABLE_TESTS_COMPILE)
+    add_subdirectory("tests")
+    add_subdirectory("datasets")
+endif()
 add_subdirectory("cfg")
 
-add_subdirectory("python_bindings")
+if (ENABLE_PYBIND_COMPILE)
+    add_subdirectory("python_bindings")
+endif()

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,59 @@
-mkdir lib
+#!/bin/bash
+
+function print_help() {
+cat << EOF
+Usage: ./build.sh [-h|--help] [-p|--pybind] [-t|--tests] [-j=N|--jobs=N]
+
+-h,     --help,          Display help
+-p,     --pybind,        Enable python bindings compile
+-t,     --tests,         Enable tests build and datasets unpacking
+-j[=N], --jobs[=N],      Allow N jobs at once. (Default [=1])
+
+EOF
+}
+
+# Set default value for jobs
+JOBS_AMOUNT=1
+
+for i in "$@"
+    do
+    case $i in
+        -p|--pybind) # Enable python bindings compile
+            PYBIND=true
+            ;;
+        -t|--tests) # Enable tests build and datasets unpacking
+            TESTS=true
+            ;;
+        -j=*|--jobs=*)
+            JOBS_AMOUNT="${i#*=}"
+            ;;
+        -h|--help|*) # Display help.
+            print_help
+            exit 0
+            ;;
+    esac
+done
+
+mkdir -p lib
 cd lib
-git clone https://github.com/google/googletest/ --branch release-1.12.1
-git clone https://github.com/amrayn/easyloggingpp/ --branch v9.97.0
-git clone https://github.com/aantron/better-enums.git --branch 0.11.3
-git clone https://github.com/pybind/pybind11.git --branch v2.10
+
+git clone https://github.com/amrayn/easyloggingpp/ --branch v9.97.0 --depth 1
+git clone https://github.com/aantron/better-enums.git --branch 0.11.3 --depth 1
+
+if [[ $TESTS == true ]]; then
+  git clone https://github.com/google/googletest/ --branch release-1.12.1 --depth 1
+else
+  PREFIX="$PREFIX -D ENABLE_TESTS_COMPILE=OFF"
+fi
+if [[ $PYBIND == true ]]; then
+  git clone https://github.com/pybind/pybind11.git --branch v2.10 --depth 1
+else
+  PREFIX="$PREFIX -D ENABLE_PYBIND_COMPILE=OFF"
+fi
+
 cd ..
-mkdir build
+mkdir -p build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=RELEASE
-make
+rm CMakeCache.txt
+cmake $PREFIX .. "-DCMAKE_BUILD_TYPE=RELEASE"
+make -j$JOBS_AMOUNT

--- a/build.sh
+++ b/build.sh
@@ -2,18 +2,19 @@
 
 function print_help() {
 cat << EOF
-Usage: ./build.sh [-h|--help] [-p|--pybind] [-t|--tests] [-j=N|--jobs=N]
+Usage: ./build.sh [-h|--help] [-p|--pybind] [-t|--tests] [-u|--unpack] [-jN|--jobs=N]
 
--h,     --help,          Display help
--p,     --pybind,        Enable python bindings compile
--t,     --tests,         Enable tests build and datasets unpacking
--j[=N], --jobs[=N],      Allow N jobs at once. (Default [=1])
-
+  -h,         --help                  Display help
+  -p,         --pybind                Compile python bindings
+  -n,         --no-tests              Don't build tests
+  -u,         --no-unpack             Don't unpack datasets
+  -j[N],      --jobs[=N]              Allow N jobs at once (default [=1])
+  -b[=type],  --build_type[=type]     Set build type (Release or Debug, default [=Release])
 EOF
 }
 
-# Set default value for jobs
-JOBS_AMOUNT=1
+# Set default option values
+BUILD_TYPE="Release"
 
 for i in "$@"
     do
@@ -21,11 +22,17 @@ for i in "$@"
         -p|--pybind) # Enable python bindings compile
             PYBIND=true
             ;;
-        -t|--tests) # Enable tests build and datasets unpacking
-            TESTS=true
+        -n|--no-tests) # Disable tests build
+            NO_TESTS=true
             ;;
-        -j=*|--jobs=*)
-            JOBS_AMOUNT="${i#*=}"
+        -u|--no-unpack) # Don't unpack datasets
+            NO_UNPACK=true
+            ;;
+        -j*|--jobs=*) # Allow N jobs at once
+            JOBS_OPTION=$i
+            ;;
+        -b=*|--build_type=*) # Set build type
+            BUILD_TYPE="${i#*=}"
             ;;
         -h|--help|*) # Display help.
             print_help
@@ -37,23 +44,35 @@ done
 mkdir -p lib
 cd lib
 
-git clone https://github.com/amrayn/easyloggingpp/ --branch v9.97.0 --depth 1
-git clone https://github.com/aantron/better-enums.git --branch 0.11.3 --depth 1
-
-if [[ $TESTS == true ]]; then
-  git clone https://github.com/google/googletest/ --branch release-1.12.1 --depth 1
-else
-  PREFIX="$PREFIX -D ENABLE_TESTS_COMPILE=OFF"
+if [[ ! -d "easyloggingpp" ]] ; then
+  git clone https://github.com/amrayn/easyloggingpp/ --branch v9.97.0 --depth 1
 fi
-if [[ $PYBIND == true ]]; then
-  git clone https://github.com/pybind/pybind11.git --branch v2.10 --depth 1
+if [[ ! -d "better-enums" ]] ; then
+  git clone https://github.com/aantron/better-enums.git --branch 0.11.3 --depth 1
+fi
+
+if [[ $NO_TESTS == true ]]; then
+  PREFIX="$PREFIX -D COMPILE_TESTS=OFF"
 else
-  PREFIX="$PREFIX -D ENABLE_PYBIND_COMPILE=OFF"
+  if [[ ! -d "googletest" ]] ; then
+    git clone https://github.com/google/googletest/ --branch release-1.12.1 --depth 1
+  fi
+fi
+
+if [[ $NO_UNPACK == true ]]; then
+  PREFIX="$PREFIX -D UNPACK_DATASETS=OFF"
+fi
+
+if [[ $PYBIND == true ]]; then
+  if [[ ! -d "pybind11" ]] ; then
+      git clone https://github.com/pybind/pybind11.git --branch v2.10 --depth 1
+  fi
+  PREFIX="$PREFIX -D COMPILE_PYBIND=ON"
 fi
 
 cd ..
 mkdir -p build
 cd build
 rm CMakeCache.txt
-cmake $PREFIX .. "-DCMAKE_BUILD_TYPE=RELEASE"
-make -j$JOBS_AMOUNT
+cmake $PREFIX .. "-DCMAKE_BUILD_TYPE=$BUILD_TYPE"
+make $JOBS_OPTION

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,5 +18,3 @@ add_custom_target(copy-files ALL
         ${CMAKE_SOURCE_DIR}/tests/input_data
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/input_data
         )
-
-


### PR DESCRIPTION
In this commit, changes are made to the scripts for building from the repository with the web version. Added the following features:
* compilation of bindings for python is made optional;
* compilation of tests and datasets unpacking is made optional;
* support for multi-threaded build option;
* skip downloading all the history up for submodules (for example, for package `easyloggingpp` we would download 769kb instead of 30mb, similar for other packages)