### PR TITLE
Add RestoreLineOrder methods for TypoMiner, add const qualifiers

### DIFF
--- a/src/algorithms/typo_miner.cpp
+++ b/src/algorithms/typo_miner.cpp
@@ -144,7 +144,7 @@ auto TypoMiner::MakeTuplesByIndicesComparator(std::map<int, unsigned> const& fre
 }
 
 std::vector<util::PLI::Cluster> TypoMiner::FindClustersWithTypos(FD const& typos_fd,
-                                                                 bool const sort_clusters) {
+                                                                 bool const sort_clusters) const {
     std::vector<util::PLI::Cluster> clusters;
     std::shared_ptr<util::PLI const> intersection_pli;
     std::vector<Column const*> const lhs_columns = typos_fd.GetLhs().GetColumns();
@@ -215,10 +215,10 @@ std::vector<util::PLI::Cluster> TypoMiner::FindClustersWithTypos(FD const& typos
 }
 
 std::vector<TypoMiner::SquashedElement> TypoMiner::SquashCluster(
-    FD const& squash_on, util::PLI::Cluster const& cluster) {
+        FD const& squash_on, util::PLI::Cluster const& cluster) const {
     std::vector<SquashedElement> squashed;
     std::vector<int> const& probing_table =
-        relation_->GetColumnData(squash_on.GetRhs().GetIndex()).GetProbingTable();
+            relation_->GetColumnData(squash_on.GetRhs().GetIndex()).GetProbingTable();
 
     if (cluster.empty()) {
         return squashed;
@@ -246,8 +246,20 @@ void TypoMiner::SortCluster(FD const& sort_on, util::PLI::Cluster& cluster) cons
     std::stable_sort(cluster.begin(), cluster.end(), MakeTuplesByIndicesComparator(frequency_map));
 }
 
+void TypoMiner::RestoreLineOrder(util::PLI::Cluster& cluster) const {
+    std::sort(cluster.begin(), cluster.end());
+}
+
+void TypoMiner::RestoreLineOrder(std::vector<TypoMiner::SquashedElement>& squashed_cluster) const {
+    std::sort(squashed_cluster.begin(), squashed_cluster.end(),
+              [](const TypoMiner::SquashedElement& lhs, const TypoMiner::SquashedElement& rhs) {
+                  return lhs.tuple_index < rhs.tuple_index;
+              });
+}
+
 std::vector<util::PLI::Cluster::value_type> TypoMiner::FindLinesWithTypos(
-    FD const& typos_fd, util::PLI::Cluster const& cluster, double new_radius, double new_ratio) {
+        FD const& typos_fd, util::PLI::Cluster const& cluster, double new_radius,
+        double new_ratio) {
     SetRadius(new_radius);
     SetRatio(new_ratio);
     return FindLinesWithTypos(typos_fd, cluster);
@@ -299,7 +311,7 @@ std::vector<util::PLI::Cluster::value_type> TypoMiner::FindLinesWithTypos(
 }
 
 std::vector<TypoMiner::ClusterTyposPair> TypoMiner::FindClustersAndLinesWithTypos(
-    const FD& typos_fd, const bool sort_clusters) {
+        const FD& typos_fd, const bool sort_clusters) const {
     std::vector<ClusterTyposPair> result;
     std::vector<util::PLI::Cluster> clusters = FindClustersWithTypos(typos_fd, sort_clusters);
 

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -41,8 +41,7 @@ private:
                                                util::PLI::Cluster const& cluster) const;
     unsigned GetMostFrequentValueIndex(Column const& cluster_col,
                                        util::PLI::Cluster const& cluster) const;
-    bool ValuesAreClose(std::byte const* l, std::byte const* r,
-                        model::Type const& type) const {
+    bool ValuesAreClose(std::byte const* l, std::byte const* r, model::Type const& type) const {
         assert(type.IsMetrizable());
         return static_cast<model::IMetrizableType const&>(type).Dist(l, r) < radius_;
     }
@@ -50,8 +49,8 @@ private:
                        std::unique_ptr<FDAlgorithm> approx_algo);
     void RegisterOptions();
     void MakeExecuteOptsAvailable() final;
-    void
-    AddSpecificNeededOptions(std::unordered_set<std::string_view> &previous_options) const final;
+    void AddSpecificNeededOptions(
+            std::unordered_set<std::string_view>& previous_options) const final;
     bool HandleUnknownOption(std::string_view const& option_name,
                              std::optional<boost::any> const& value) final;
     int TrySetOption(std::string_view const& option_name,
@@ -71,25 +70,31 @@ public:
     explicit TypoMiner(PrimitiveType precise, PrimitiveType approx = PrimitiveType::pyro);
 
     std::vector<util::PLI::Cluster> FindClustersWithTypos(FD const& typos_fd,
-                                                          bool const sort_clusters = true);
+                                                          bool const sort_clusters = true) const;
     /* Returns squashed representation of a cluster with respect to given fd.
      * Check description of SquashedElement. Two tuples are considered equal if they are
      * equal in rhs attribute of given fd (they are automatically equal in lhs too if clusters
      * were retrieved from FindClustersWithTypos()).
      */
     std::vector<SquashedElement> SquashCluster(FD const& squash_on,
-                                               util::PLI::Cluster const& cluster);
+                                               util::PLI::Cluster const& cluster) const;
     /* Sorts given cluster in ascending order by uniqueness of the values in rhs of sort_on fd.
      * More strictly:
      * t1 tuple is considered less than t2 tuple iff t1[sort_on.rhs] is less frequent value
      * in rhs column than t2[sort_on.rhs].
      */
     void SortCluster(FD const& sort_on, util::PLI::Cluster& cluster) const;
+
+    /* Sorts given cluster in ascending order of the indices */
+    void RestoreLineOrder(util::PLI::Cluster& cluster) const;
+    /* Sorts given squashed cluster in ascending order of the indices */
+    void RestoreLineOrder(std::vector<TypoMiner::SquashedElement>& squashed_cluster) const;
+
     /* Finds lines in a cluster that has typos on typos_fd.GetRhs() column values. A value is said
      * to contain a typo if it differs from the most frequent value in the cluster by less
      * than radius_ and the fraction of such values (values_num / cluster_size) is less than ratio_.
-     * NOTE: The cluster argument is asumed to be consistent with the rhs of typos_fd, i.e.
-     * indices in the cluster represent value indices in the typos_fd.GetRhs() column. Otherwise
+     * NOTE: The cluster argument is assumed to be consistent with the rhs of typos_fd, i.e.
+     * indices in the cluster represent value indices in the typos_fd.GetRhs() column. Otherwise,
      * the behavior of this method is undefined.
      * Most likely you want to pass to this method as arguments pure approximate FD some_fd and
      * a cluster retrieved from the FindClustersWithTypos(some_fd).
@@ -97,8 +102,8 @@ public:
     TyposVec FindLinesWithTypos(FD const& typos_fd, util::PLI::Cluster const& cluster) const;
     TyposVec FindLinesWithTypos(FD const& typos_fd, util::PLI::Cluster const& cluster,
                                 double new_radius, double new_ratio);
-    std::vector<ClusterTyposPair> FindClustersAndLinesWithTypos(FD const& typos_fd,
-                                                                bool const sort_clusters = true);
+    std::vector<ClusterTyposPair> FindClustersAndLinesWithTypos(
+            FD const& typos_fd, bool const sort_clusters = true) const;
 
     /* Returns vector of approximate fds only (there are no precise fds) */
     std::vector<FD> const& GetApproxFDs() const noexcept {


### PR DESCRIPTION
* Added forgotten constant qualifiers
* Add `RestoreLineOrder` method