### PR TITLE
Don't examine the diff context when checking formatting

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -13,7 +13,7 @@ jobs:
         sudo apt-get install -y clang-format-12
     - name: Check formatting
       run: |       
-        formatterOutput=$( git diff origin/$GITHUB_BASE_REF...HEAD | clang-format-diff-12 -p 1)
+        formatterOutput=$( git diff -U0 origin/$GITHUB_BASE_REF...HEAD | clang-format-diff-12 -p 1)
         
         if [ "$formatterOutput" != "" ]
         then


### PR DESCRIPTION
Since by default `git diff` shows a lot of context around the changes made, clang-format checks their formatting too which is redundant. Fully removing the context from the diff should be fine: new changes definitely should not violate the formatting while old code near the changes can be checked by the reviewer manually.