### PR TITLE
Separate primitive progress logic, `HyFD::Preprocess` logic and primitive collection logic 

### DIFF
--- a/src/algorithms/depminer/depminer.cpp
+++ b/src/algorithms/depminer/depminer.cpp
@@ -46,7 +46,7 @@ unsigned long long Depminer::ExecuteInternal() {
     const auto lhs_elapsed_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now() - lhs_time);
     LOG(INFO) << "> LHS FIND TIME: " << lhs_elapsed_milliseconds.count();
-    LOG(INFO) << "> FD COUNT: " << this->fd_collection_.size();
+    LOG(INFO) << "> FD COUNT: " << this->fd_collection_.Size();
     const auto elapsed_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now() - start_time);
     return elapsed_milliseconds.count();

--- a/src/algorithms/dfd/dfd.cpp
+++ b/src/algorithms/dfd/dfd.cpp
@@ -83,7 +83,7 @@ unsigned long long DFD::ExecuteInternal() {
         std::chrono::system_clock::now() - start_time);
     long long apriori_millis = elapsed_milliseconds.count();
 
-    LOG(INFO) << "> FD COUNT: " << fd_collection_.size();
+    LOG(INFO) << "> FD COUNT: " << fd_collection_.Size();
     LOG(INFO) << "> HASH: " << PliBasedFDAlgorithm::Fletcher16();
 
     return apriori_millis;

--- a/src/algorithms/fd_algorithm.cpp
+++ b/src/algorithms/fd_algorithm.cpp
@@ -22,12 +22,12 @@ void FDAlgorithm::FitInternal(model::IDatasetStream& data_stream) {
 }
 
 void FDAlgorithm::ResetState() {
-    fd_collection_.clear();
+    fd_collection_.Clear();
     ResetStateFd();
 }
 
 std::string FDAlgorithm::GetJsonFDs() const {
-    return FDsToJson(fd_collection_);
+    return FDsToJson(FdList());
 }
 
 unsigned int FDAlgorithm::Fletcher16() {
@@ -50,7 +50,7 @@ std::vector<Column const*> FDAlgorithm::GetKeys() const {
     std::map<Column const*, size_t> fds_count_per_col;
     unsigned int cols_of_equal_values = 0;
 
-    for (FD const& fd : fd_collection_) {
+    for (FD const& fd : FdList()) {
         Vertical const& lhs = fd.GetLhs();
 
         if (lhs.GetArity() == 0) {

--- a/src/algorithms/fdep/fdep.cpp
+++ b/src/algorithms/fdep/fdep.cpp
@@ -57,7 +57,7 @@ unsigned long long FDep::ExecuteInternal() {
     std::bitset<FDTreeElement::kMaxAttrNum> active_path;
     CalculatePositiveCover(*this->neg_cover_tree_, active_path);
 
-    pos_cover_tree_->FillFdCollection(*this->schema_, fd_collection_);
+    pos_cover_tree_->FillFdCollection(*this->schema_, FdList());
 
     auto elapsed_milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now() - start_time);

--- a/src/algorithms/hyfd/hyfd.cpp
+++ b/src/algorithms/hyfd/hyfd.cpp
@@ -11,91 +11,20 @@
 #include <easylogging++.h>
 
 #include "algorithms/hyfd/inductor.h"
+#include "algorithms/hyfd/preprocessor.h"
 #include "algorithms/hyfd/sampler.h"
 #include "algorithms/hyfd/util/pli_util.h"
 #include "algorithms/hyfd/validator.h"
-
-namespace {
-
-std::vector<size_t> SortAndGetMapping(algos::hyfd::PLIs& plis) {
-    size_t id = 0;
-    std::vector<std::pair<algos::hyfd::PLIs::value_type, size_t>> plis_sort_ids;
-    std::transform(plis.begin(), plis.end(), std::back_inserter(plis_sort_ids),
-                   [&id](auto& pli) { return std::make_pair(std::move(pli), id++); });
-
-    auto const kClusterQuantityDescending = [](auto const& pli1, auto const& pli2) {
-        return pli1.first->GetNumCluster() > pli2.first->GetNumCluster();
-    };
-    std::sort(plis_sort_ids.begin(), plis_sort_ids.end(), kClusterQuantityDescending);
-
-    std::transform(plis_sort_ids.begin(), plis_sort_ids.end(), plis.begin(),
-                   [](auto& pli_ext) { return std::move(pli_ext.first); });
-
-    std::vector<size_t> og_mapping(plis_sort_ids.size());
-    std::transform(plis_sort_ids.begin(), plis_sort_ids.end(), og_mapping.begin(),
-                   [](auto const& pli_ext) { return pli_ext.second; });
-    return og_mapping;
-}
-
-algos::hyfd::Columns BuildInvertedPlis(algos::hyfd::PLIs const& plis) {
-    algos::hyfd::Columns inverted_plis;
-
-    for (auto const& pli : plis) {
-        size_t cluster_id = 0;
-        std::vector<size_t> current(pli->getRelationSize(),
-                                    algos::hyfd::PLIUtil::kSingletonClusterId);
-        for (const auto& cluster : pli->GetIndex()) {
-            for (int value : cluster) {
-                current[value] = cluster_id;
-            }
-            cluster_id++;
-        }
-        inverted_plis.push_back(std::move(current));
-    }
-    return inverted_plis;
-}
-
-algos::hyfd::Rows BuildRecordRepresentation(algos::hyfd::Columns const& inverted_plis) {
-    size_t const num_columns = inverted_plis.size();
-    size_t const num_rows = num_columns == 0 ? 0 : inverted_plis.begin()->size();
-
-    algos::hyfd::Rows pli_records(num_rows, std::vector<size_t>(num_columns));
-
-    for (size_t i = 0; i < num_rows; ++i) {
-        for (size_t j = 0; j < num_columns; ++j) {
-            pli_records[i][j] = inverted_plis[j][i];
-        }
-    }
-
-    return pli_records;
-}
-
-}  // namespace
 
 namespace algos::hyfd {
 
 HyFD::HyFD() : PliBasedFDAlgorithm({}) {}
 
-std::tuple<PLIs, Rows, std::vector<size_t>> HyFD::Preprocess() {
-    PLIs plis;
-    std::transform(relation_->GetColumnData().begin(), relation_->GetColumnData().end(),
-                   std::back_inserter(plis),
-                   [](auto& columnData) { return columnData.GetPositionListIndex(); });
-
-    auto og_mapping = SortAndGetMapping(plis);
-
-    const auto inverted_plis = BuildInvertedPlis(plis);
-
-    auto pli_records = BuildRecordRepresentation(inverted_plis);
-
-    return std::make_tuple(std::move(plis), std::move(pli_records), std::move(og_mapping));
-}
-
 unsigned long long HyFD::ExecuteInternal() {
     LOG(TRACE) << "Executing";
     auto const start_time = std::chrono::system_clock::now();
 
-    auto [plis, pli_records, og_mapping] = Preprocess();
+    auto [plis, pli_records, og_mapping] = Preprocess(relation_.get());
     auto const plis_shared = std::make_shared<PLIs>(std::move(plis));
     auto const pli_records_shared = std::make_shared<Rows>(std::move(pli_records));
 

--- a/src/algorithms/hyfd/hyfd.h
+++ b/src/algorithms/hyfd/hyfd.h
@@ -40,7 +40,6 @@ private:
     void ResetStateFd() final {}
     unsigned long long ExecuteInternal() override;
 
-    std::tuple<PLIs, Columns, std::vector<size_t>> Preprocess();
     void RegisterFDs(std::vector<RawFD>&& fds, std::vector<size_t> const& og_mapping);
 
 public:

--- a/src/algorithms/hyfd/preprocessor.cpp
+++ b/src/algorithms/hyfd/preprocessor.cpp
@@ -1,0 +1,82 @@
+#include "preprocessor.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "util/pli_util.h"
+
+namespace {
+
+std::vector<size_t> SortAndGetMapping(algos::hyfd::PLIs& plis) {
+    size_t id = 0;
+    std::vector<std::pair<algos::hyfd::PLIs::value_type, size_t>> plis_sort_ids;
+    std::transform(plis.begin(), plis.end(), std::back_inserter(plis_sort_ids),
+                   [&id](auto& pli) { return std::make_pair(std::move(pli), id++); });
+
+    auto const kClusterQuantityDescending = [](auto const& pli1, auto const& pli2) {
+        return pli1.first->GetNumCluster() > pli2.first->GetNumCluster();
+    };
+    std::sort(plis_sort_ids.begin(), plis_sort_ids.end(), kClusterQuantityDescending);
+
+    std::transform(plis_sort_ids.begin(), plis_sort_ids.end(), plis.begin(),
+                   [](auto& pli_ext) { return std::move(pli_ext.first); });
+
+    std::vector<size_t> og_mapping(plis_sort_ids.size());
+    std::transform(plis_sort_ids.begin(), plis_sort_ids.end(), og_mapping.begin(),
+                   [](auto const& pli_ext) { return pli_ext.second; });
+    return og_mapping;
+}
+
+algos::hyfd::Columns BuildInvertedPlis(algos::hyfd::PLIs const& plis) {
+    algos::hyfd::Columns inverted_plis;
+
+    for (auto const& pli : plis) {
+        size_t cluster_id = 0;
+        std::vector<size_t> current(pli->getRelationSize(),
+                                    algos::hyfd::PLIUtil::kSingletonClusterId);
+        for (const auto& cluster : pli->GetIndex()) {
+            for (int value : cluster) {
+                current[value] = cluster_id;
+            }
+            cluster_id++;
+        }
+        inverted_plis.push_back(std::move(current));
+    }
+    return inverted_plis;
+}
+
+algos::hyfd::Rows BuildRecordRepresentation(algos::hyfd::Columns const& inverted_plis) {
+    size_t const num_columns = inverted_plis.size();
+    size_t const num_rows = num_columns == 0 ? 0 : inverted_plis.begin()->size();
+
+    algos::hyfd::Rows pli_records(num_rows, std::vector<size_t>(num_columns));
+
+    for (size_t i = 0; i < num_rows; ++i) {
+        for (size_t j = 0; j < num_columns; ++j) {
+            pli_records[i][j] = inverted_plis[j][i];
+        }
+    }
+
+    return pli_records;
+}
+
+}  // namespace
+
+namespace algos::hyfd {
+
+std::tuple<PLIs, Rows, std::vector<size_t>> Preprocess(ColumnLayoutRelationData* relation) {
+    PLIs plis;
+    std::transform(relation->GetColumnData().begin(), relation->GetColumnData().end(),
+                   std::back_inserter(plis),
+                   [](auto& columnData) { return columnData.GetPositionListIndex(); });
+
+    auto og_mapping = SortAndGetMapping(plis);
+
+    const auto inverted_plis = BuildInvertedPlis(plis);
+
+    auto pli_records = BuildRecordRepresentation(inverted_plis);
+
+    return std::make_tuple(std::move(plis), std::move(pli_records), std::move(og_mapping));
+}
+
+}  // namespace algos::hyfd

--- a/src/algorithms/hyfd/preprocessor.h
+++ b/src/algorithms/hyfd/preprocessor.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <tuple>
+
+#include "model/column_layout_relation_data.h"
+#include "types.h"
+
+namespace algos::hyfd {
+
+std::tuple<PLIs, Rows, std::vector<size_t>> Preprocess(ColumnLayoutRelationData *relation);
+
+}  // namespace algos::hyfd

--- a/src/model/ar.h
+++ b/src/model/ar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <list>
+
 #include "itemset.h"
 #include "transactional_data.h"
 

--- a/src/util/primitive_collection.h
+++ b/src/util/primitive_collection.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <list>
+#include <mutex>
+
+namespace util {
+
+/* Represents the collection of the primitive instances, guarantees the thread safety of adding
+ * new instances
+ */
+template <typename T>
+class PrimitiveCollection {
+private:
+    std::list<T> collection_;
+    std::mutex mutable mutex_;
+
+public:
+    void Register(T primitive) {
+        std::scoped_lock lock(mutex_);
+        collection_.push_back(std::move(primitive));
+    }
+
+    template <typename... Args>
+    void Register(Args&&... args) {
+        std::scoped_lock lock(mutex_);
+        collection_.emplace_back(std::forward<Args>(args)...);
+    }
+
+    void Clear() noexcept {
+        std::scoped_lock lock(mutex_);
+        collection_.clear();
+    }
+
+    size_t Size() const noexcept {
+        std::scoped_lock lock(mutex_);
+        return collection_.size();
+    }
+
+    /* Calling code MUST guarantee that methods below won't interfere with the registering of
+     * new primitive instances or clearing (for the entire time the returned reference is held).
+     * Practically this means that these methods should be called only after algorithm is finished
+     * its execution.
+     */
+    std::list<T> const& AsList() const noexcept {
+        return collection_;
+    }
+
+    std::list<T>& AsList() noexcept {
+        return collection_;
+    }
+};
+
+}  // namespace util

--- a/src/util/progress.cpp
+++ b/src/util/progress.cpp
@@ -1,0 +1,39 @@
+#include "progress.h"
+
+namespace util {
+
+void Progress::AddProgress(double val) noexcept {
+    assert(val >= 0);
+    std::scoped_lock lock(progress_mutex_);
+    cur_phase_progress_ += val;
+    assert(cur_phase_progress_ < 101);
+}
+
+void Progress::SetProgress(double val) noexcept {
+    assert(0 <= val && val < 101);
+    std::scoped_lock lock(progress_mutex_);
+    cur_phase_progress_ = val;
+}
+
+std::pair<uint8_t, double> Progress::GetProgress() const noexcept {
+    std::scoped_lock lock(progress_mutex_);
+    return std::make_pair(cur_phase_id_, cur_phase_progress_);
+}
+
+void Progress::ResetProgress() noexcept {
+    std::scoped_lock lock(progress_mutex_);
+    cur_phase_progress_ = 0;
+    cur_phase_id_ = 0;
+}
+
+void Progress::ToNextProgressPhase() noexcept {
+    // Current phase is done, ensure that this is displayed in the progress bar
+    SetProgress(kTotalProgressPercent);
+
+    std::scoped_lock lock(progress_mutex_);
+    ++cur_phase_id_;
+    assert(cur_phase_id_ < phase_names_.size());
+    cur_phase_progress_ = 0;
+}
+
+}  // namespace util

--- a/src/util/progress.h
+++ b/src/util/progress.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cassert>
+#include <mutex>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace util {
+
+// Describes a progress of a primitive mining algorithm.
+// Progress of the algorithm is represented as a set of phases each of which has separate double
+// value between 0 and 100. This value descibes progress of specific phase in natural way:
+// 0 - nothing done yet, 100 - the phase is finished and each value in between represents the
+// percentage of the work associated with the phase done.
+class Progress {
+private:
+    std::mutex mutable progress_mutex_;
+    double cur_phase_progress_ = 0;
+    uint8_t cur_phase_id_ = 0;
+    std::vector<std::string_view> phase_names_;
+
+public:
+    constexpr static double kTotalProgressPercent = 100.0;
+
+    explicit Progress(std::vector<std::string_view> phase_names)
+        : phase_names_(std::move(phase_names)) {}
+
+    // Adds value to the progress of the current phase
+    void AddProgress(double val) noexcept;
+    // Sets value of the progress of the current phase
+    void SetProgress(double val) noexcept;
+    // Resets current phase and its progress to zeros
+    void ResetProgress() noexcept;
+    // Returns pair with current progress state.
+    // Pair has the form <current phase id, current phase progess>
+    std::pair<uint8_t, double> GetProgress() const noexcept;
+    // Finishes current phase and moves to the next one
+    void ToNextProgressPhase() noexcept;
+    std::vector<std::string_view> const& GetPhaseNames() const noexcept {
+        return phase_names_;
+    }
+};
+
+}  // namespace util


### PR DESCRIPTION
This pull request does minor refactoring, mainly:
  - Moves the `HyFD::Preprocess` code to a separate function so that it can be used later in `HyUCC`;
  - Implements auxiliary class for a collection of primitives and uses it in `FDAlgorithm` to encapsulate this logic and simplify the reuse of this code;
  - Implements auxiliary class for the progress of primitive mining algorithm for the same purposes as with `PrimitiveCollection`.
 