### PR TITLE
Add Undefined Behavior Sanitizer

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        BUILD_TYPE: [ Release, Debug ]
+        cfg:
+          - { BUILD_TYPE: Release  }
+          - { BUILD_TYPE: Debug }
+          - { BUILD_TYPE: Debug, SANITIZER : ADDRESS }
+          - { BUILD_TYPE: Debug, SANITIZER : UB }
     steps:
     - uses: actions/checkout@v3
     - name: Download libraries
@@ -26,10 +30,11 @@ jobs:
         -DCMAKE_C_COMPILER=gcc-10
         -DCMAKE_CXX_COMPILER=g++-10
         -DBOOST_ROOT=${{github.workspace}}/lib/boost
-        -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}}
+        -DCMAKE_BUILD_TYPE=${{matrix.cfg.BUILD_TYPE}}
+        -DSANITIZER=${{matrix.cfg.SANITIZER}}
         -Dgtest_disable_pthreads=OFF
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.cfg.BUILD_TYPE}}
     - name: Test
       working-directory: ${{github.workspace}}/build/target
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,22 @@ option(COMPILE_PYBIND "Build the python bindings" OFF)
 option(COPY_PYTHON_EXAMPLES "Copy Python examples" OFF)
 option(COMPILE_TESTS "Build tests" ON)
 option(UNPACK_DATASETS "Unpack datasets" ON)
-option(ASAN "Enable Address Sanitizer" ON)
+set(SANITIZER "" CACHE STRING "Build with sanitizer, possible values: ADDRESS, UB")
 
 # By default select Debug build
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif(NOT CMAKE_BUILD_TYPE)
+
+if (SANITIZER)
+    if (SANITIZER STREQUAL "ADDRESS")
+        set(ASAN ON)
+    elseif (SANITIZER STREQUAL "UB")
+        set(UBSAN ON)
+    else ()
+        message(FATAL_ERROR "Unknown sanitizer '${SANITIZER}', try cmake -LH")
+    endif ()
+endif ()
 
 if (ASAN AND COMPILE_PYBIND)
     message(WARNING "Disabling ASAN with python bindings.")
@@ -42,7 +52,8 @@ else()
         "-Wall"
         "-Wextra"
         "-Werror"
-        "-fno-omit-frame-pointer")
+        "-fno-omit-frame-pointer"
+        "-fno-optimize-sibling-calls")
 
     if (ASAN)
         # Set DEBUG build options specific for build with ASAN
@@ -51,6 +62,21 @@ else()
             "-O0"
             "${ASAN_OPTS}")
         set(DEBUG_LINK_OPTS "${ASAN_OPTS}")
+    elseif (UBSAN)
+        # Set DEBUG build options specific for build with UBSAN
+        string(JOIN ";" UBSAN_OPTS "-fsanitize=undefined"
+            "-fsanitize=float-divide-by-zero"
+            "-fno-sanitize=signed-integer-overflow" # Remove this when CustomRandom gets fixed
+            "-fno-sanitize=shift" # Remove this when CustomRandom gets fixed
+            "-fno-sanitize-recover=all") # For tests to fail if UBSan finds an error
+        string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}"
+            "-O1"
+            "${UBSAN_OPTS}")
+        set(DEBUG_LINK_OPTS "${UBSAN_OPTS}")
+    else ()
+        # No sanitizer, just debug build
+        string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}"
+            "-O0")
     endif()
 
     add_compile_options("$<$<CONFIG:Debug>:${DEBUG_BUILD_OPTS}>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ option(COMPILE_PYBIND "Build the python bindings" OFF)
 option(COPY_PYTHON_EXAMPLES "Copy Python examples" OFF)
 option(COMPILE_TESTS "Build tests" ON)
 option(UNPACK_DATASETS "Unpack datasets" ON)
-option(ASAN "Enable sanitizer" ON)
+option(ASAN "Enable Address Sanitizer" ON)
 
 # By default select Debug build
 if(NOT CMAKE_BUILD_TYPE)
@@ -13,7 +13,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 if (ASAN AND COMPILE_PYBIND)
-    message(WARNING "Disabling ASAN with python bindings")
+    message(WARNING "Disabling ASAN with python bindings.")
     set(ASAN OFF)
 endif()
 
@@ -28,12 +28,35 @@ if (MSVC)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE  "${CMAKE_BINARY_DIR}/target")
 else()
     # -DELPP_THREAD_SAFE -- for easylogging++ thread safety
-    add_compile_options("$<$<CONFIG:Debug>:-O0;-DELPP_THREAD_SAFE;-g;-Wall;-Wextra;-Werror;-fno-omit-frame-pointer>")
+    set(BUILD_OPTS "-DELPP_THREAD_SAFE")
+
+    # RELEASE build options
+    string(JOIN ";" RELEASE_BUILD_OPTS "${BUILD_OPTS}"
+        "-O3")
+
+    set(DEBUG_BUILD_OPTS "${BUILD_OPTS}")
+
+    # Set common DEBUG build options
+    string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}"
+        "-g"
+        "-Wall"
+        "-Wextra"
+        "-Werror"
+        "-fno-omit-frame-pointer")
+
     if (ASAN)
-        add_compile_options("$<$<CONFIG:Debug>:-fsanitize=address>")
-        add_link_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+        # Set DEBUG build options specific for build with ASAN
+        set(ASAN_OPTS "-fsanitize=address")
+        string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}"
+            "-O0"
+            "${ASAN_OPTS}")
+        set(DEBUG_LINK_OPTS "${ASAN_OPTS}")
     endif()
-    add_compile_options("$<$<CONFIG:Release>:-O3;-DELPP_THREAD_SAFE>")
+
+    add_compile_options("$<$<CONFIG:Debug>:${DEBUG_BUILD_OPTS}>")
+    add_link_options("$<$<CONFIG:Debug>:${DEBUG_LINK_OPTS}>")
+
+    add_compile_options("$<$<CONFIG:Release>:${RELEASE_BUILD_OPTS}>")
 endif()
 
 # configuring boost

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ else()
         # Set DEBUG build options specific for build with ASAN
         set(ASAN_OPTS "-fsanitize=address")
         string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}"
-            "-O0"
+            "-O1"
             "${ASAN_OPTS}")
         set(DEBUG_LINK_OPTS "${ASAN_OPTS}")
     elseif (UBSAN)

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,10 @@ Usage: ./build.sh [-h|--help] [-p|--pybind] [-n|--no-test]
   -u,         --no-unpack             Don't unpack datasets
   -j[N],      --jobs[=N]              Allow N jobs at once (default [=1])
   -d,         --debug                 Set debug build type
+  -s[S],      --sanitizer[=S]         Build with sanitizer S (has effect only for debug build).
+                                      Possible values of S: ADDRESS, UB.
+                                      ADDRESS - Address Sanitizer
+                                      UB      - Undefined Behavior Sanitizer
 
 EOF
 }
@@ -18,10 +22,10 @@ EOF
 for i in "$@"
     do
     case $i in
-        -p|--pybind) # Enable python bindings compile
+        -p|--pybind) # Compile python bindings
             PYBIND=true
             ;;
-        -n|--no-tests) # Disable tests build
+        -n|--no-tests) # Don't build tests
             NO_TESTS=true
             ;;
         -u|--no-unpack) # Don't unpack datasets
@@ -33,7 +37,15 @@ for i in "$@"
         -d|--debug) # Set debug build type
             DEBUG_MODE=true
             ;;
-        -h|--help|*) # Display help.
+        # It's a nightmare, we should use getopts for args parsing or even use something else
+        # instead of bash
+        --sanitizer=*) # Build with sanitizer S, long option
+            SANITIZER="${i#*=}"
+            ;;
+        -s*) # Build with sanitizer S, short option
+            SANITIZER="${i#*s}"
+            ;;
+        -h|--help|*) # Display help
             print_help
             exit 0
             ;;
@@ -71,6 +83,10 @@ fi
 
 if [[ $DEBUG_MODE != true ]]; then
   PREFIX="$PREFIX -D CMAKE_BUILD_TYPE=Release"
+fi
+
+if [[ -v SANITIZER ]]; then
+  PREFIX="$PREFIX -D SANITIZER=${SANITIZER}"
 fi
 
 cd ..

--- a/build.sh
+++ b/build.sh
@@ -93,5 +93,4 @@ cd ..
 mkdir -p build
 cd build
 rm CMakeCache.txt
-cmake $PREFIX ..
-make $JOBS_OPTION
+cmake $PREFIX .. && make $JOBS_OPTION

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,9 @@
 
 function print_help() {
 cat << EOF
-Usage: ./build.sh [-h|--help] [-p|--pybind] [-n|--no-test]
-                  [-u|--no-unpack] [-jN|--jobs=N] [-d|--debug]
+Usage: ./build.sh [options]
 
+Possible options:
   -h,         --help                  Display help
   -p,         --pybind                Compile python bindings
   -n,         --no-tests              Don't build tests

--- a/src/core/algorithms/fd/fd_algorithm.cpp
+++ b/src/core/algorithms/fd/fd_algorithm.cpp
@@ -1,6 +1,8 @@
 #include "fd_algorithm.h"
 
+#include <map>
 #include <thread>
+#include <vector>
 
 #include "config/equal_nulls/option.h"
 #include "config/tabular_data/input_table/option.h"


### PR DESCRIPTION
Add option to compile Desbordante with Undefined Behavior Sanitizer to cmake and to `build.sh`. Add the workflow which runs tests with UB Sanitizer to CI. 