### PR TITLE
Don't post LGTM comment in clang-tidy workflow

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -120,6 +120,7 @@ jobs:
       with:
         build_dir: build
         config_file: '.clang-tidy'
+        lgtm_comment_body: ''
         split_workflow: true
 
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
It's not very informative and is posted after every workflow run. So if author of the PR often triggers the workflow (because of force-pushes with patch fixes for example), they will be spammed with this comment.