### PR TITLE
Get correct right neighbor when sorting clusters in hyfd::Sampler

### DIFF
--- a/src/algorithms/hyfd/sampler.cpp
+++ b/src/algorithms/hyfd/sampler.cpp
@@ -61,7 +61,7 @@ public:
     }
 
     [[nodiscard]] size_t GetRightNeighbor() const {
-        return GetDecrement(current_column_compared_);
+        return GetIncrement(current_column_compared_);
     }
 };
 


### PR DESCRIPTION
If two current records are equal or unknown in the left neighbor's PLIs during sorting of PLI clusters we should examine the right neighbor. Currently `ColumnSlider` returns the same attribute for left neighbor and for right neighbor, which is wrong.