### PR TITLE
Expose some MetricVerifier configuration options

### DIFF
--- a/src/algorithms/metric/metric_verifier.h
+++ b/src/algorithms/metric/metric_verifier.h
@@ -96,6 +96,18 @@ public:
         return metric_fd_holds_;
     }
 
+    config::IndicesType const& GetLhsIndices() const {
+        return lhs_indices_;
+    }
+
+    config::IndicesType const& GetRhsIndices() const {
+        return rhs_indices_;
+    }
+
+    long double GetParameter() const {
+        return parameter_;
+    }
+
     std::vector<std::vector<Highlight>> const& GetHighlights() const {
         return highlight_calculator_->GetHighlights();
     }


### PR DESCRIPTION
In order to allow backend cpp-consumer service to generate MFD highlights some of MetricVerifier configuration options have to be publicly available.

See https://github.com/vs9h/Desbordante/pull/77 for details