### PR TITLE
Make lgtm_comment_body empty in PostReview workflow

### DIFF
--- a/.github/workflows/post-review.yml
+++ b/.github/workflows/post-review.yml
@@ -37,6 +37,8 @@ jobs:
 
       - uses: ZedThree/clang-tidy-review/post@v0.10.0
         id: post
+        with:
+          lgtm_comment_body: ''
 
       # If there are any comments, fail the check
       - if: steps.post.outputs.total_comments > 0


### PR DESCRIPTION
It seems like it's not sufficient to specify lgtm_comment_body as empty in main workflow (which generates the review). PostReview ignores it and continues to spam with lgtm comments.
Also see #182