### PR TITLE
Move common code for Hybrind algorithms (HyUCC and HyFD) to hycommon

### DIFF
--- a/src/algorithms/hycommon/all_column_combinations.cpp
+++ b/src/algorithms/hycommon/all_column_combinations.cpp
@@ -1,10 +1,10 @@
-#include "non_fds.h"
+#include "all_column_combinations.h"
 
 #include <utility>
 
 #include <boost/dynamic_bitset.hpp>
 
-namespace algos::hyfd {
+namespace algos::hy {
 
 void AllColumnCombinations::Add(boost::dynamic_bitset<>&& column_set) {
     if (total_ccs_.insert(column_set).second) {
@@ -19,4 +19,4 @@ ColumnCombinationList AllColumnCombinations::MoveOutNewColumnCombinations() {
     return old;
 }
 
-}  // namespace algos::hyfd
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/all_column_combinations.h
+++ b/src/algorithms/hycommon/all_column_combinations.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include <boost/dynamic_bitset.hpp>
+
+#include "column_combination_list.h"
+
+namespace algos::hy {
+
+/**
+ * Collection of column combinations found by the Sampler.
+ *
+ * Stores combinations found during the lifetime as well as combinations found since
+ * the last access.
+ */
+class AllColumnCombinations {
+private:
+    std::unordered_set<boost::dynamic_bitset<>> total_ccs_;
+    ColumnCombinationList new_ccs_;
+
+public:
+    explicit AllColumnCombinations(size_t num_attributes) : new_ccs_(num_attributes) {}
+
+    /**
+     * Adds given column combination to the lifetime storage.
+     * If the storage had no such combination, it is added to the last-access storage as well.
+     *
+     * @param column_set column combination
+     */
+    void Add(boost::dynamic_bitset<>&& column_set);
+
+    /**
+     * @return Number of column sets stored in the last-access storage.
+     */
+    [[nodiscard]] size_t Count() const {
+        return new_ccs_.GetTotalCount();
+    }
+
+    /**
+     * @return Collection of violating column sets found since this method previous call.
+     * @see NonFDList
+     */
+    ColumnCombinationList MoveOutNewColumnCombinations();
+
+    [[nodiscard]] size_t NumAttributes() const {
+        return new_ccs_.GetNumAttributes();
+    }
+};
+
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/column_combination_list.h
+++ b/src/algorithms/hycommon/column_combination_list.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include <boost/dynamic_bitset.hpp>
+
+namespace algos::hy {
+
+/**
+ * Collection of column combinations found by the Sampler module.
+ * In the HyFD algorithm column combination repesents a non-FD.
+ * In the HyUCC algorithm column combination repesents a non-UCC.
+ *
+ * Stores combinations with the same column count as a separate level.
+ */
+class ColumnCombinationList {
+private:
+    std::vector<std::vector<boost::dynamic_bitset<>>> ccs_;
+    unsigned depth_ = 0;
+
+public:
+    explicit ColumnCombinationList(size_t num_attributes) : ccs_(num_attributes + 1) {}
+
+    /**
+     * Adds the column combination to the correspondent level. Does not check whether the level
+     * already contains such a combination.
+     *
+     * @param column_set column combination to add.
+     */
+    void Add(boost::dynamic_bitset<>&& column_set) {
+        unsigned level = column_set.count();
+
+        ccs_[level].push_back(std::move(column_set));
+        if (level > depth_) {
+            depth_ = level;
+        }
+    }
+
+    size_t GetNumAttributes() const noexcept {
+        return ccs_.size() - 1;
+    }
+
+    /**
+     * @return Highest level containing any number of combinations.
+     */
+    [[nodiscard]] unsigned GetDepth() const noexcept {
+        return depth_;
+    }
+
+    /**
+     * @return Collection of column combination with given column count.
+     */
+    [[nodiscard]] std::vector<boost::dynamic_bitset<>> const& GetLevel(size_t level) const {
+        return ccs_.at(level);
+    }
+
+    /**
+     * @return Total count of stored column combinations accross all levels.
+     */
+    [[nodiscard]] size_t GetTotalCount() const {
+        return std::accumulate(ccs_.cbegin(), ccs_.cend(), 0,
+                               [](size_t res, auto const& v) { return res + v.size(); });
+    }
+};
+
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/efficiency.h
+++ b/src/algorithms/hycommon/efficiency.h
@@ -2,7 +2,7 @@
 
 #include "sampler.h"
 
-namespace algos::hyfd {
+namespace algos::hy {
 
 class Sampler::Efficiency {
 private:
@@ -48,4 +48,4 @@ public:
     }
 };
 
-}  // namespace algos::hyfd
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/efficiency_threshold.h
+++ b/src/algorithms/hycommon/efficiency_threshold.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace algos::hy {
+
+inline constexpr double kEfficiencyThreshold = 0.01;
+
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/preprocessor.cpp
+++ b/src/algorithms/hycommon/preprocessor.cpp
@@ -7,9 +7,9 @@
 
 namespace {
 
-std::vector<size_t> SortAndGetMapping(algos::hyfd::PLIs& plis) {
+std::vector<size_t> SortAndGetMapping(algos::hy::PLIs& plis) {
     size_t id = 0;
-    std::vector<std::pair<algos::hyfd::PLIs::value_type, size_t>> plis_sort_ids;
+    std::vector<std::pair<algos::hy::PLIs::value_type, size_t>> plis_sort_ids;
     std::transform(plis.begin(), plis.end(), std::back_inserter(plis_sort_ids),
                    [&id](auto& pli) { return std::make_pair(std::move(pli), id++); });
 
@@ -27,13 +27,13 @@ std::vector<size_t> SortAndGetMapping(algos::hyfd::PLIs& plis) {
     return og_mapping;
 }
 
-algos::hyfd::Columns BuildInvertedPlis(algos::hyfd::PLIs const& plis) {
-    algos::hyfd::Columns inverted_plis;
+algos::hy::Columns BuildInvertedPlis(algos::hy::PLIs const& plis) {
+    algos::hy::Columns inverted_plis;
 
     for (auto const& pli : plis) {
         size_t cluster_id = 0;
         std::vector<size_t> current(pli->getRelationSize(),
-                                    algos::hyfd::PLIUtil::kSingletonClusterId);
+                                    algos::hy::PLIUtil::kSingletonClusterId);
         for (const auto& cluster : pli->GetIndex()) {
             for (int value : cluster) {
                 current[value] = cluster_id;
@@ -45,11 +45,11 @@ algos::hyfd::Columns BuildInvertedPlis(algos::hyfd::PLIs const& plis) {
     return inverted_plis;
 }
 
-algos::hyfd::Rows BuildRecordRepresentation(algos::hyfd::Columns const& inverted_plis) {
+algos::hy::Rows BuildRecordRepresentation(algos::hy::Columns const& inverted_plis) {
     size_t const num_columns = inverted_plis.size();
     size_t const num_rows = num_columns == 0 ? 0 : inverted_plis.begin()->size();
 
-    algos::hyfd::Rows pli_records(num_rows, std::vector<size_t>(num_columns));
+    algos::hy::Rows pli_records(num_rows, std::vector<size_t>(num_columns));
 
     for (size_t i = 0; i < num_rows; ++i) {
         for (size_t j = 0; j < num_columns; ++j) {
@@ -62,7 +62,7 @@ algos::hyfd::Rows BuildRecordRepresentation(algos::hyfd::Columns const& inverted
 
 }  // namespace
 
-namespace algos::hyfd {
+namespace algos::hy {
 
 std::tuple<PLIs, Rows, std::vector<size_t>> Preprocess(ColumnLayoutRelationData* relation) {
     PLIs plis;
@@ -88,4 +88,4 @@ boost::dynamic_bitset<> RestoreAgreeSet(boost::dynamic_bitset<> const& as,
     return mapped_as;
 }
 
-}  // namespace algos::hyfd
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/preprocessor.h
+++ b/src/algorithms/hycommon/preprocessor.h
@@ -7,10 +7,10 @@
 #include "model/column_layout_relation_data.h"
 #include "types.h"
 
-namespace algos::hyfd {
+namespace algos::hy {
 
-std::tuple<PLIs, Rows, std::vector<size_t>> Preprocess(ColumnLayoutRelationData *relation);
+std::tuple<PLIs, Rows, std::vector<size_t>> Preprocess(ColumnLayoutRelationData* relation);
 boost::dynamic_bitset<> RestoreAgreeSet(boost::dynamic_bitset<> const& as,
                                         std::vector<size_t> const& og_mapping, size_t num_cols);
 
-}  // namespace algos::hyfd
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/primitive_validations.h
+++ b/src/algorithms/hycommon/primitive_validations.h
@@ -3,7 +3,7 @@
 
 #include "types.h"
 
-namespace algos::hyfd {
+namespace algos::hy {
 
 template <typename RawPrimitive>
 class PrimitiveValidations {
@@ -53,4 +53,4 @@ public:
     }
 };
 
-}  // namespace algos::hyfd
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/sampler.h
+++ b/src/algorithms/hycommon/sampler.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+#include <queue>
+#include <vector>
+
+#include <boost/dynamic_bitset.hpp>
+
+#include "all_column_combinations.h"
+#include "efficiency_threshold.h"
+#include "types.h"
+#include "util/position_list_index.h"
+
+namespace algos::hy {
+
+class Sampler {
+private:
+    class Efficiency;
+    double efficiency_threshold_ = kEfficiencyThreshold;
+
+    PLIsPtr plis_;
+    RowsPtr compressed_records_;
+    std::priority_queue<Efficiency> efficiency_queue_;
+
+    std::unique_ptr<AllColumnCombinations> agree_sets_;
+
+    void ProcessComparisonSuggestions(IdPairs const& comparison_suggestions);
+    void InitializeEfficiencyQueue();
+
+    void Match(boost::dynamic_bitset<>& attributes, size_t first_record_id,
+               size_t second_record_id);
+    void RunWindow(Efficiency& efficiency, util::PositionListIndex const& pli);
+
+public:
+    Sampler(PLIsPtr plis, RowsPtr pli_records);
+
+    Sampler(Sampler const& other) = delete;
+    Sampler(Sampler&& other) = delete;
+    Sampler& operator=(Sampler const& other) = delete;
+    Sampler& operator=(Sampler&& other) = delete;
+    ~Sampler();
+
+    ColumnCombinationList GetAgreeSets(IdPairs const& comparison_suggestions);
+};
+
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/types.h
+++ b/src/algorithms/hycommon/types.h
@@ -8,7 +8,7 @@ class PositionListIndex;
 
 }
 
-namespace algos::hyfd {
+namespace algos::hy {
 
 // Represents a relation as a list of position list indexes. i-th PLI is a PLI built on i-th column
 // of the relation
@@ -22,4 +22,4 @@ using RowsPtr = std::shared_ptr<Rows>;
 // Pair of row numbers
 using IdPairs = std::vector<std::pair<size_t, size_t>>;
 
-}  // namespace algos::hyfd
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/util/pli_util.h
+++ b/src/algorithms/hycommon/util/pli_util.h
@@ -2,7 +2,7 @@
 
 #include <cstddef>
 
-namespace algos::hyfd {
+namespace algos::hy {
 
 class PLIUtil {
 public:
@@ -13,4 +13,4 @@ public:
     }
 };
 
-}  // namespace algos::hyfd
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/validator_helpers.cpp
+++ b/src/algorithms/hycommon/validator_helpers.cpp
@@ -1,9 +1,9 @@
 #include "validator_helpers.h"
 
 #include "hyfd/structures/fd_tree_vertex.h"
-#include "hyfd/util/pli_util.h"
+#include "util/pli_util.h"
 
-namespace algos {
+namespace algos::hy {
 
 std::vector<size_t> BuildClustersIdentifier(std::vector<size_t> const& compressed_record,
                                             std::vector<size_t> const& agree_set) {
@@ -12,7 +12,7 @@ std::vector<size_t> BuildClustersIdentifier(std::vector<size_t> const& compresse
     for (size_t attr : agree_set) {
         size_t const cluster_id = compressed_record[attr];
 
-        if (!algos::hyfd::PLIUtil::IsSingletonCluster(cluster_id)) {
+        if (!PLIUtil::IsSingletonCluster(cluster_id)) {
             sub_cluster.push_back(cluster_id);
         } else {
             return {};
@@ -49,4 +49,4 @@ using FDLhsPair = algos::hyfd::fd_tree::LhsPair;
 template std::vector<FDLhsPair> CollectCurrentChildren<FDLhsPair>(
         std::vector<FDLhsPair> const& cur_level_vertices, size_t num_attributes);
 
-}  // namespace algos
+}  // namespace algos::hy

--- a/src/algorithms/hycommon/validator_helpers.h
+++ b/src/algorithms/hycommon/validator_helpers.h
@@ -8,7 +8,7 @@
 #include <boost/dynamic_bitset.hpp>
 #include <easylogging++.h>
 
-namespace algos {
+namespace algos::hy {
 
 // Builds a cluster's identifier of the agree set provided. Cluster's identifier is a vector
 // of size_t value where ith value of the vector is an identifier of a cluster of ith set
@@ -41,4 +41,4 @@ auto MakeClusterIdentifierToTMap(size_t bucket_size) {
     return std::unordered_map<std::vector<size_t>, T, decltype(kHasher)>(bucket_size, kHasher);
 }
 
-}  // namespace algos
+}  // namespace algos::hy

--- a/src/algorithms/hyfd/hyfd.cpp
+++ b/src/algorithms/hyfd/hyfd.cpp
@@ -10,10 +10,10 @@
 #include <boost/dynamic_bitset.hpp>
 #include <easylogging++.h>
 
+#include "algorithms/hycommon/preprocessor.h"
+#include "algorithms/hycommon/util/pli_util.h"
 #include "algorithms/hyfd/inductor.h"
-#include "algorithms/hyfd/preprocessor.h"
 #include "algorithms/hyfd/sampler.h"
-#include "algorithms/hyfd/util/pli_util.h"
 #include "algorithms/hyfd/validator.h"
 
 namespace algos::hyfd {
@@ -21,6 +21,7 @@ namespace algos::hyfd {
 HyFD::HyFD() : PliBasedFDAlgorithm({}) {}
 
 unsigned long long HyFD::ExecuteInternal() {
+    using namespace hy;
     LOG(TRACE) << "Executing";
     auto const start_time = std::chrono::system_clock::now();
 
@@ -65,7 +66,7 @@ void HyFD::RegisterFDs(std::vector<RawFD>&& fds, const std::vector<size_t>& og_m
     const auto* const schema = GetRelation().GetSchema();
     for (auto&& [lhs, rhs] : fds) {
         boost::dynamic_bitset<> mapped_lhs =
-                RestoreAgreeSet(lhs, og_mapping, schema->GetNumColumns());
+                hy::RestoreAgreeSet(lhs, og_mapping, schema->GetNumColumns());
         Vertical lhs_v(schema, std::move(mapped_lhs));
 
         size_t const mapped_rhs = og_mapping[rhs];

--- a/src/algorithms/hyfd/hyfd.h
+++ b/src/algorithms/hyfd/hyfd.h
@@ -5,7 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include "algorithms/hyfd/types.h"
 #include "algorithms/pli_based_fd_algorithm.h"
 #include "model/raw_fd.h"
 #include "util/position_list_index.h"

--- a/src/algorithms/hyfd/hyfd_config.h
+++ b/src/algorithms/hyfd/hyfd_config.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "hycommon/efficiency_threshold.h"
+
 namespace algos::hyfd {
 
 class HyFDConfig {
 public:
-    static constexpr double kEfficiencyThreshold = 0.01;
+    static constexpr double kEfficiencyThreshold = hy::kEfficiencyThreshold;
 };
 
 }  // namespace algos::hyfd

--- a/src/algorithms/hyfd/sampler.h
+++ b/src/algorithms/hyfd/sampler.h
@@ -1,46 +1,20 @@
 #pragma once
-
-#include <memory>
-#include <queue>
-#include <vector>
-
-#include <boost/dynamic_bitset.hpp>
-
-#include "hyfd_config.h"
-#include "structures/non_fds.h"
-#include "types.h"
-#include "util/position_list_index.h"
+#include "hycommon/sampler.h"
+#include "hyfd/structures/non_fd_list.h"
 
 namespace algos::hyfd {
 
 class Sampler {
 private:
-    class Efficiency;
-    double efficiency_threshold_ = HyFDConfig::kEfficiencyThreshold;
-
-    PLIsPtr plis_;
-    RowsPtr compressed_records_;
-    std::priority_queue<Efficiency> efficiency_queue_;
-
-    std::unique_ptr<NonFds> non_fds_;
-
-    void ProcessComparisonSuggestions(IdPairs const& comparison_suggestions);
-    void InitializeEfficiencyQueue();
-
-    void Match(boost::dynamic_bitset<>& attributes, size_t first_record_id,
-               size_t second_record_id);
-    void RunWindow(Efficiency& efficiency, util::PositionListIndex const& pli);
+    hy::Sampler sampler_;
 
 public:
-    Sampler(PLIsPtr plis, RowsPtr pli_records);
+    Sampler(hy::PLIsPtr plis, hy::RowsPtr pli_records)
+        : sampler_(std::move(plis), std::move(pli_records)) {}
 
-    Sampler(Sampler const& other)               = delete;
-    Sampler(Sampler && other)                   = delete;
-    Sampler& operator=(Sampler const& other)    = delete;
-    Sampler& operator=(Sampler && other)        = delete;
-    ~Sampler();
-
-    NonFDList GetNonFDCandidates(IdPairs const& comparison_suggestions);
+    NonFDList GetNonFDCandidates(hy::IdPairs const& comparison_suggestions) {
+        return sampler_.GetAgreeSets(comparison_suggestions);
+    }
 };
 
 }  // namespace algos::hyfd

--- a/src/algorithms/hyfd/structures/non_fd_list.h
+++ b/src/algorithms/hyfd/structures/non_fd_list.h
@@ -6,65 +6,10 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+#include "hycommon/column_combination_list.h"
+
 namespace algos::hyfd {
 
-/**
- * Collection of column combinations found by the Sampler module.
- * In the HyFD algorithm column combination repesents a non-FD.
- * In the HyUCC algorithm column combination repesents a non-UCC.
- *
- * Stores combinations with the same column count as a separate level.
- */
-class ColumnCombinationList {
-private:
-    std::vector<std::vector<boost::dynamic_bitset<>>> ccs_;
-    unsigned depth_ = 0;
-
-public:
-    explicit ColumnCombinationList(size_t num_attributes) : ccs_(num_attributes + 1) {}
-
-    /**
-     * Adds the column combination to the correspondent level. Does not check whether the level
-     * already contains such a combination.
-     *
-     * @param column_set column combination to add.
-     */
-    void Add(boost::dynamic_bitset<>&& column_set) {
-        unsigned level = column_set.count();
-
-        ccs_[level].push_back(std::move(column_set));
-        if (level > depth_) {
-            depth_ = level;
-        }
-    }
-
-    size_t GetNumAttributes() const noexcept {
-        return ccs_.size() - 1;
-    }
-
-    /**
-     * @return Highest level containing any number of combinations.
-     */
-    [[nodiscard]] unsigned GetDepth() const noexcept {
-        return depth_;
-    }
-
-    /**
-     * @return Collection of column combination with given column count.
-     */
-    [[nodiscard]] std::vector<boost::dynamic_bitset<>> const& GetLevel(size_t level) const {
-        return ccs_.at(level);
-    }
-
-    /**
-     * @return Total count of stored column combinations accross all levels.
-     */
-    [[nodiscard]] size_t GetTotalCount() const {
-        return std::accumulate(ccs_.cbegin(), ccs_.cend(), 0,
-                               [](size_t res, auto const& v) { return res + v.size(); });
-    }
-};
-
-using NonFDList = ColumnCombinationList;
+using NonFDList = hy::ColumnCombinationList;
 
 }  // namespace algos::hyfd

--- a/src/algorithms/hyfd/structures/non_fds.h
+++ b/src/algorithms/hyfd/structures/non_fds.h
@@ -5,50 +5,10 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-#include "non_fd_list.h"
+#include "hycommon/all_column_combinations.h"
 
 namespace algos::hyfd {
 
-/**
- * Collection of column combinations found by the Sampler.
- *
- * Stores combinations found during the lifetime as well as combinations found since
- * the last access.
- */
-class AllColumnCombinations {
-private:
-    std::unordered_set<boost::dynamic_bitset<>> total_ccs_;
-    ColumnCombinationList new_ccs_;
-
-public:
-    explicit AllColumnCombinations(size_t num_attributes) : new_ccs_(num_attributes) {}
-
-    /**
-     * Adds given column combination to the lifetime storage.
-     * If the storage had no such combination, it is added to the last-access storage as well.
-     *
-     * @param column_set column combination
-     */
-    void Add(boost::dynamic_bitset<>&& column_set);
-
-    /**
-     * @return Number of column sets stored in the last-access storage.
-     */
-    [[nodiscard]] size_t Count() const {
-        return new_ccs_.GetTotalCount();
-    }
-
-    /**
-     * @return Collection of violating column sets found since this method previous call.
-     * @see NonFDList
-     */
-    ColumnCombinationList MoveOutNewColumnCombinations();
-
-    [[nodiscard]] size_t NumAttributes() const {
-        return new_ccs_.GetNumAttributes();
-    }
-};
-
-using NonFds = AllColumnCombinations;
+using NonFds = hy::AllColumnCombinations;
 
 }  // namespace algos::hyfd

--- a/src/algorithms/hyfd/validator.h
+++ b/src/algorithms/hyfd/validator.h
@@ -4,7 +4,7 @@
 #include <utility>
 #include <vector>
 
-#include "primitive_validations.h"
+#include "hycommon/primitive_validations.h"
 #include "raw_fd.h"
 #include "structures/fd_tree.h"
 #include "structures/non_fds.h"
@@ -17,12 +17,12 @@ using LhsPair = fd_tree::LhsPair;
 
 class Validator {
 private:
-    using FDValidations = PrimitiveValidations<RawFD>;
+    using FDValidations = hy::PrimitiveValidations<RawFD>;
 
     std::shared_ptr<fd_tree::FDTree> fds_;
 
-    PLIsPtr plis_;
-    RowsPtr compressed_records_;
+    hy::PLIsPtr plis_;
+    hy::RowsPtr compressed_records_;
 
     unsigned current_level_number_ = 0;
 
@@ -39,13 +39,13 @@ private:
     }
 
 public:
-    Validator(std::shared_ptr<fd_tree::FDTree> fds, PLIsPtr plis,
-              RowsPtr compressed_records) noexcept
+    Validator(std::shared_ptr<fd_tree::FDTree> fds, hy::PLIsPtr plis,
+              hy::RowsPtr compressed_records) noexcept
         : fds_(std::move(fds)),
           plis_(std::move(plis)),
           compressed_records_(std::move(compressed_records)) {}
 
-    IdPairs ValidateAndExtendCandidates();
+    hy::IdPairs ValidateAndExtendCandidates();
 };
 
 }  // namespace algos::hyfd

--- a/src/util/bitset_utils.h
+++ b/src/util/bitset_utils.h
@@ -20,9 +20,10 @@ template <typename Index>
 std::vector<Index> BitsetToIndices(boost::dynamic_bitset<> const& bitset) {
     std::vector<Index> indices;
     indices.reserve(bitset.count());
-    for (Index i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
+    for (size_t i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
          i = bitset.find_next(i)) {
-        indices.push_back(i);
+        assert(i <= std::numeric_limits<Index>::max());
+        indices.push_back(static_cast<Index>(i));
     }
     return indices;
 }


### PR DESCRIPTION
Move common code for HyUCC and HyFD to different namespace and to different directory to separate this code both logically and physically from the specific HyFD (or HyUCC) code
Also fix a small bug in `util::BitsetToIndices` with narrow conversions which appears when `std::numeric_limits<Index>::max()` is less than  `std::numeric_limits<size_t>::max()`