### PR TITLE
Rename `Fit` to `LoadData`

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -99,13 +99,13 @@ PYBIND11_MODULE(desbordante, module) {
                                    &FDHighlight::GetMostFrequentRhsValueProportion);
 
     py::class_<PyAlgorithmBase>(module, "Algorithm")
-            .def("fit",
+            .def("load_data",
                  py::overload_cast<std::string const &, char, bool, py::kwargs const &>(
-                         &PyAlgorithmBase::Fit),
+                         &PyAlgorithmBase::LoadData),
                  "path"_a, "separator"_a = ',', "has_header"_a = true, "Transform data from CSV")
-            .def("fit",
+            .def("load_data",
                  py::overload_cast<pybind11::object, std::string, py::kwargs const &>(
-                         &PyAlgorithmBase::Fit),
+                         &PyAlgorithmBase::LoadData),
                  "df"_a, "name"_a = "Pandas dataframe", "Transform data from pandas dataframe")
             .def("get_needed_options", &PyAlgorithmBase::GetNeededOptions,
                  "Get names of options the algorithm needs")

--- a/python_bindings/examples/dedupe.py
+++ b/python_bindings/examples/dedupe.py
@@ -23,7 +23,7 @@ CONFIG_STRING = f"""Deduplication parameters:
 
 def get_1lhs_fds(df, algo_name, algo_config):
     algo = getattr(desb, algo_name)()
-    algo.fit(df, **algo_config)
+    algo.load_data(df, **algo_config)
     algo.execute(**algo_config)
     return sorted((lhs_indices[0], fd.rhs_index) for fd in algo.get_fds()
                   if len(lhs_indices := fd.lhs_indices) == 1)

--- a/python_bindings/examples/mine_typos.py
+++ b/python_bindings/examples/mine_typos.py
@@ -121,7 +121,7 @@ def fd_to_string(dataset: pd.DataFrame, fd: tuple[tuple[int], int]):
 
 def get_result_set(df, algo_name, algo_config):
     algo = getattr(desb, algo_name)()
-    algo.fit(df, **algo_config)
+    algo.load_data(df, **algo_config)
     algo.execute(**algo_config)
     return {(tuple(fd.lhs_indices), fd.rhs_index) for fd in algo.get_fds()}
 

--- a/python_bindings/py_algorithm.cpp
+++ b/python_bindings/py_algorithm.cpp
@@ -49,24 +49,24 @@ py::tuple PyAlgorithmBase::GetOptionType(std::string_view option_name) const {
     return GetPyType(type_index);
 }
 
-void PyAlgorithmBase::Fit(std::string const& path, char separator, bool has_header,
-                          py::kwargs const& kwargs) {
+void PyAlgorithmBase::LoadData(std::string const& path, char separator, bool has_header,
+                               py::kwargs const& kwargs) {
     Configure(kwargs);
     CSVParser parser{path, separator, has_header};
-    algorithm_->Fit(parser);
+    algorithm_->LoadData(parser);
 }
 
-void PyAlgorithmBase::Fit(py::object dataframe, std::string name, py::kwargs const& kwargs) {
+void PyAlgorithmBase::LoadData(py::object dataframe, std::string name, py::kwargs const& kwargs) {
     Configure(kwargs);
 
     py::handle const& dtypes = dataframe.attr("dtypes");
     if (dtypes[dtypes.attr("__ne__")(py::str{"string"})].attr("empty").cast<bool>()) {
         // All columns are python strings, no need to transform.
         StringDataframeReader reader{std::move(dataframe), std::move(name)};
-        algorithm_->Fit(reader);
+        algorithm_->LoadData(reader);
     } else {
         ArbitraryDataframeReader reader{std::move(dataframe), std::move(name)};
-        algorithm_->Fit(reader);
+        algorithm_->LoadData(reader);
     }
 }
 

--- a/python_bindings/py_algorithm.h
+++ b/python_bindings/py_algorithm.h
@@ -27,10 +27,10 @@ public:
     [[nodiscard]] pybind11::tuple GetOptionType(std::string_view option_name) const;
 
     // For pandas dataframes
-    void Fit(pybind11::object dataframe, std::string name, pybind11::kwargs const& kwargs);
+    void LoadData(pybind11::object dataframe, std::string name, pybind11::kwargs const& kwargs);
 
-    void Fit(std::string const& path, char separator, bool has_header,
-             pybind11::kwargs const& kwargs);
+    void LoadData(std::string const& path, char separator, bool has_header,
+                  pybind11::kwargs const& kwargs);
 
     pybind11::int_ Execute(pybind11::kwargs const& kwargs);
 };

--- a/src/algorithms/aidfd/aid.cpp
+++ b/src/algorithms/aidfd/aid.cpp
@@ -4,7 +4,7 @@ namespace algos {
 
 Aid::Aid() : FDAlgorithm({kDefaultPhaseName}) {}
 
-void Aid::FitFd(model::IDatasetStream& data_stream) {
+void Aid::LoadDataFd(model::IDatasetStream& data_stream) {
     number_of_attributes_ = data_stream.GetNumberOfColumns();
     if (number_of_attributes_ == 0) {
         throw std::runtime_error("Unable to work on an empty dataset.");

--- a/src/algorithms/aidfd/aid.h
+++ b/src/algorithms/aidfd/aid.h
@@ -40,7 +40,7 @@ private:
 
     void ResetStateFd() final;
 
-    void FitFd(model::IDatasetStream &data_stream) final;
+    void LoadDataFd(model::IDatasetStream& data_stream) final;
     unsigned long long ExecuteInternal() final;
 
     void BuildClusters();

--- a/src/algorithms/algo_factory.h
+++ b/src/algorithms/algo_factory.h
@@ -103,7 +103,7 @@ void LoadAlgorithm(Algorithm& algorithm, OptionMap&& options) {
             details::ExtractOptionValue<std::filesystem::path>(options, config::names::kData),
             details::ExtractOptionValue<char>(options, config::names::kSeparator),
             details::ExtractOptionValue<bool>(options, config::names::kHasHeader)};
-    algorithm.Fit(parser);
+    algorithm.LoadData(parser);
     ConfigureFromMap(algorithm, options);
 }
 

--- a/src/algorithms/algorithm.cpp
+++ b/src/algorithms/algorithm.cpp
@@ -9,8 +9,8 @@ bool Algorithm::HandleUnknownOption([[maybe_unused]] std::string_view option_nam
     return false;
 }
 
-bool Algorithm::FitCompleted() const {
-    return fit_completed_;
+bool Algorithm::DataLoaded() const {
+    return data_loaded_;
 }
 
 void Algorithm::AddSpecificNeededOptions(
@@ -24,7 +24,7 @@ void Algorithm::ClearOptions() noexcept {
 }
 
 void Algorithm::ExecutePrepare() {
-    fit_completed_ = true;
+    data_loaded_ = true;
     ClearOptions();
     MakeExecuteOptsAvailable();
 }
@@ -62,16 +62,16 @@ void Algorithm::MakeOptionsAvailable(std::vector<std::string_view> const& option
     }
 }
 
-void Algorithm::Fit(model::IDatasetStream& data_stream) {
+void Algorithm::LoadData(model::IDatasetStream& data_stream) {
     if (!GetNeededOptions().empty()) throw std::logic_error(
                 "All options need to be set before starting processing.");
-    FitInternal(data_stream);
+    LoadDataInternal(data_stream);
     data_stream.Reset();
     ExecutePrepare();
 }
 
 unsigned long long Algorithm::Execute() {
-    if (!fit_completed_) {
+    if (!data_loaded_) {
         throw std::logic_error("Data must be processed before execution.");
     }
     if (!GetNeededOptions().empty())

--- a/src/algorithms/algorithm.h
+++ b/src/algorithms/algorithm.h
@@ -28,7 +28,7 @@ private:
     // Maps a parameter that added other parameters to their names.
     std::unordered_map<std::string_view, std::vector<std::string_view>> opt_parents_{};
 
-    bool fit_completed_ = false;
+    bool data_loaded_ = false;
 
     // Clear the necessary fields for Execute to run repeatedly with different
     // configuration parameters on the same dataset.
@@ -36,7 +36,7 @@ private:
 
     void ExcludeOptions(std::string_view parent_option) noexcept;
     void ClearOptions() noexcept;
-    virtual void FitInternal(model::IDatasetStream& data_stream) = 0;
+    virtual void LoadDataInternal(model::IDatasetStream& data_stream) = 0;
     virtual unsigned long long ExecuteInternal() = 0;
 
 protected:
@@ -67,7 +67,7 @@ protected:
     void ExecutePrepare();
 
     // Overload this to add options after your algorithm has processed the data
-    // given through Fit
+    // given through LoadData
     virtual void MakeExecuteOptsAvailable();
 
 public:
@@ -83,8 +83,8 @@ public:
     // NOTE: Pass an empty vector here if your algorithm does not have an implemented progress bar.
     explicit Algorithm(std::vector<std::string_view> phase_names);
 
-    void Fit(model::IDatasetStream & data_stream);
-    bool FitCompleted() const;
+    void LoadData(model::IDatasetStream& data_stream);
+    bool DataLoaded() const;
 
     unsigned long long Execute();
 

--- a/src/algorithms/ar_algorithm.cpp
+++ b/src/algorithms/ar_algorithm.cpp
@@ -42,7 +42,7 @@ void ARAlgorithm::MakeExecuteOptsAvailable() {
     MakeOptionsAvailable({kMinimumSupport, kMinimumConfidence});
 }
 
-void ARAlgorithm::FitInternal(model::IDatasetStream& data_stream) {
+void ARAlgorithm::LoadDataInternal(model::IDatasetStream& data_stream) {
     switch (input_format_) {
         case InputFormat::singular:
             transactional_data_ = model::TransactionalData::CreateFromSingular(

--- a/src/algorithms/ar_algorithm.h
+++ b/src/algorithms/ar_algorithm.h
@@ -56,7 +56,7 @@ protected:
     virtual double GetSupport(std::vector<unsigned> const& frequent_itemset) const = 0;
     virtual unsigned long long GenerateAllRules() = 0;
     virtual unsigned long long FindFrequent() = 0;
-    void FitInternal(model::IDatasetStream &data_stream) final;
+    void LoadDataInternal(model::IDatasetStream& data_stream) final;
     void MakeExecuteOptsAvailable() final;
     unsigned long long ExecuteInternal() final;
 

--- a/src/algorithms/fd_algorithm.cpp
+++ b/src/algorithms/fd_algorithm.cpp
@@ -16,9 +16,9 @@ void FDAlgorithm::RegisterOptions() {
     RegisterOption(config::EqualNullsOpt(&is_null_equal_null_));
 }
 
-void FDAlgorithm::FitInternal(model::IDatasetStream& data_stream) {
+void FDAlgorithm::LoadDataInternal(model::IDatasetStream& data_stream) {
     number_of_columns_ = data_stream.GetNumberOfColumns();
-    FitFd(data_stream);
+    LoadDataFd(data_stream);
 }
 
 void FDAlgorithm::ResetState() {

--- a/src/algorithms/fd_algorithm.h
+++ b/src/algorithms/fd_algorithm.h
@@ -49,8 +49,8 @@ protected:
         fd_collection_.Register(std::move(fd_to_register));
     }
 
-    void FitInternal(model::IDatasetStream &data_stream) final;
-    virtual void FitFd(model::IDatasetStream &data_stream) = 0;
+    void LoadDataInternal(model::IDatasetStream& data_stream) final;
+    virtual void LoadDataFd(model::IDatasetStream& data_stream) = 0;
 
 public:
     constexpr static std::string_view kDefaultPhaseName = "FD mining";

--- a/src/algorithms/fd_verifier/fd_verifier.cpp
+++ b/src/algorithms/fd_verifier/fd_verifier.cpp
@@ -36,7 +36,7 @@ void FDVerifier::MakeExecuteOptsAvailable() {
     MakeOptionsAvailable({config::LhsIndicesOpt.GetName(), kRhsIndex});
 }
 
-void FDVerifier::FitInternal(model::IDatasetStream& data_stream) {
+void FDVerifier::LoadDataInternal(model::IDatasetStream& data_stream) {
     relation_ = ColumnLayoutRelationData::CreateFrom(data_stream, is_null_equal_null_);
     data_stream.Reset();
     if (relation_->GetColumnData().empty()) {

--- a/src/algorithms/fd_verifier/fd_verifier.h
+++ b/src/algorithms/fd_verifier/fd_verifier.h
@@ -33,7 +33,7 @@ private:
     }
 
 protected:
-    void FitInternal(model::IDatasetStream& data_stream) override;
+    void LoadDataInternal(model::IDatasetStream& data_stream) override;
     void MakeExecuteOptsAvailable() override;
     unsigned long long ExecuteInternal() override;
 

--- a/src/algorithms/fdep/fdep.cpp
+++ b/src/algorithms/fdep/fdep.cpp
@@ -12,7 +12,7 @@ namespace algos {
 
 FDep::FDep() : FDAlgorithm({kDefaultPhaseName}) {}
 
-void FDep::FitFd(model::IDatasetStream& data_stream) {
+void FDep::LoadDataFd(model::IDatasetStream& data_stream) {
     number_attributes_ = data_stream.GetNumberOfColumns();
     if (number_attributes_ == 0) {
         throw std::runtime_error("Unable to work on an empty dataset.");

--- a/src/algorithms/fdep/fdep.h
+++ b/src/algorithms/fdep/fdep.h
@@ -27,7 +27,7 @@ private:
 
     std::vector<std::vector<size_t>> tuples_;
 
-    void FitFd(model::IDatasetStream &data_stream) final;
+    void LoadDataFd(model::IDatasetStream& data_stream) final;
 
     void ResetStateFd() final;
     unsigned long long ExecuteInternal() final;

--- a/src/algorithms/legacy_algorithm.h
+++ b/src/algorithms/legacy_algorithm.h
@@ -15,7 +15,7 @@ namespace algos {
 
 class LegacyAlgorithm : public Algorithm {
 private:
-    void FitInternal([[maybe_unused]] model::IDatasetStream& data_stream) override {}
+    void LoadDataInternal([[maybe_unused]] model::IDatasetStream& data_stream) override {}
 
     void ResetState() final {}
 

--- a/src/algorithms/metric/metric_verifier.cpp
+++ b/src/algorithms/metric/metric_verifier.cpp
@@ -119,7 +119,7 @@ void MetricVerifier::MakeExecuteOptsAvailable() {
             {kDistFromNullIsInfinity, kParameter, kMetric, config::LhsIndicesOpt.GetName()});
 }
 
-void MetricVerifier::FitInternal(model::IDatasetStream& data_stream) {
+void MetricVerifier::LoadDataInternal(model::IDatasetStream& data_stream) {
     relation_ = ColumnLayoutRelationData::CreateFrom(data_stream, is_null_equal_null_);
     data_stream.Reset();
     if (relation_->GetColumnData().empty()) {

--- a/src/algorithms/metric/metric_verifier.h
+++ b/src/algorithms/metric/metric_verifier.h
@@ -80,7 +80,7 @@ private:
     void ResetState() final;
 
 protected:
-    void FitInternal(model::IDatasetStream& data_stream) override;
+    void LoadDataInternal(model::IDatasetStream& data_stream) override;
     void MakeExecuteOptsAvailable() override;
     unsigned long long ExecuteInternal() override;
 

--- a/src/algorithms/pli_based_fd_algorithm.cpp
+++ b/src/algorithms/pli_based_fd_algorithm.cpp
@@ -5,7 +5,7 @@ namespace algos {
 PliBasedFDAlgorithm::PliBasedFDAlgorithm(std::vector<std::string_view> phase_names)
         : FDAlgorithm(std::move(phase_names)) {}
 
-void PliBasedFDAlgorithm::FitFd(model::IDatasetStream& data_stream) {
+void PliBasedFDAlgorithm::LoadDataFd(model::IDatasetStream& data_stream) {
     relation_ = ColumnLayoutRelationData::CreateFrom(data_stream, is_null_equal_null_);
 
     if (relation_->GetColumnData().empty()) {
@@ -26,13 +26,13 @@ std::vector<Column const*> PliBasedFDAlgorithm::GetKeys() const {
     return keys;
 }
 
-void PliBasedFDAlgorithm::Fit(std::shared_ptr<ColumnLayoutRelationData> data) {
+void PliBasedFDAlgorithm::LoadData(std::shared_ptr<ColumnLayoutRelationData> data) {
     if (data->GetColumnData().empty()) {
         throw std::runtime_error("Got an empty dataset: FD mining is meaningless.");
-    }  // TODO: this has to be repeated for every "alternative" Fit
+    }  // TODO: this has to be repeated for every "alternative" data load
     number_of_columns_ = data->GetNumColumns();
     relation_ = std::move(data);
-    ExecutePrepare();  // TODO: this has to be repeated for every "alternative" Fit
+    ExecutePrepare();  // TODO: this has to be repeated for every "alternative" data load
 }
 
 }  // namespace algos

--- a/src/algorithms/pli_based_fd_algorithm.h
+++ b/src/algorithms/pli_based_fd_algorithm.h
@@ -9,7 +9,7 @@ class PliBasedFDAlgorithm : public FDAlgorithm {
 protected:
     std::shared_ptr<ColumnLayoutRelationData> relation_;
 
-    void FitFd(model::IDatasetStream& data_stream) final;
+    void LoadDataFd(model::IDatasetStream& data_stream) final;
 
     ColumnLayoutRelationData const& GetRelation() const noexcept {
         // GetRelation should be called after the dataset has been parsed, i.e. after algorithm
@@ -23,8 +23,8 @@ public:
 
     std::vector<Column const*> GetKeys() const override;
 
-    using Algorithm::Fit;
-    void Fit(std::shared_ptr<ColumnLayoutRelationData> data);
+    using Algorithm::LoadData;
+    void LoadData(std::shared_ptr<ColumnLayoutRelationData> data);
 };
 
 }  // namespace algos

--- a/src/algorithms/statistics/data_stats.cpp
+++ b/src/algorithms/statistics/data_stats.cpp
@@ -480,7 +480,7 @@ std::string DataStats::ToString() const {
     return res.str();
 }
 
-void DataStats::FitInternal(model::IDatasetStream& data_stream) {
+void DataStats::LoadDataInternal(model::IDatasetStream& data_stream) {
     col_data_ = mo::CreateTypedColumnData(data_stream, is_null_equal_null_);
     all_stats_ = std::vector<ColumnStats>{col_data_.size()};
 }

--- a/src/algorithms/statistics/data_stats.h
+++ b/src/algorithms/statistics/data_stats.h
@@ -28,7 +28,7 @@ class DataStats : public Algorithm {
     Statistic CountIfInBinaryRelationWithZero(size_t index, model::CompareResult res) const;
 
 protected:
-    void FitInternal(model::IDatasetStream &data_stream) final;
+    void LoadDataInternal(model::IDatasetStream& data_stream) final;
     void MakeExecuteOptsAvailable() final;
     unsigned long long ExecuteInternal() final;
 

--- a/src/algorithms/typo_miner.cpp
+++ b/src/algorithms/typo_miner.cpp
@@ -84,7 +84,7 @@ int TypoMiner::TrySetOption(std::string_view option_name, boost::any const& valu
 void TypoMiner::AddSpecificNeededOptions(std::unordered_set<std::string_view>& previous_options) const {
     auto precise_options = precise_algo_->GetNeededOptions();
     auto approx_options = approx_algo_->GetNeededOptions();
-    if (!FitCompleted()) {
+    if (!DataLoaded()) {
         // blocked by TypoMiner's is_null_equal_null option
         precise_options.erase(config::names::kEqualNulls);
         approx_options.erase(config::names::kEqualNulls);
@@ -93,7 +93,7 @@ void TypoMiner::AddSpecificNeededOptions(std::unordered_set<std::string_view>& p
     previous_options.insert(approx_options.begin(), approx_options.end());
 }
 
-void TypoMiner::FitInternal(model::IDatasetStream& data_stream) {
+void TypoMiner::LoadDataInternal(model::IDatasetStream& data_stream) {
     relation_ = ColumnLayoutRelationData::CreateFrom(data_stream, is_null_equal_null_);
     data_stream.Reset();
     typed_relation_ =
@@ -103,17 +103,17 @@ void TypoMiner::FitInternal(model::IDatasetStream& data_stream) {
     auto approx_pli = dynamic_cast<PliBasedFDAlgorithm*>(approx_algo_.get());
     boost::any null_opt_any{is_null_equal_null_};
     TrySetOption(config::EqualNullsOpt.GetName(), null_opt_any, null_opt_any);
-    if (!precise_algo_->FitCompleted()) {
+    if (!precise_algo_->DataLoaded()) {
         if (precise_pli != nullptr)
-            precise_pli->Fit(relation_);
+            precise_pli->LoadData(relation_);
         else
-            precise_algo_->Fit(data_stream);
+            precise_algo_->LoadData(data_stream);
     }
-    if (!approx_algo_->FitCompleted()) {
+    if (!approx_algo_->DataLoaded()) {
         if (approx_pli != nullptr)
-            approx_pli->Fit(relation_);
+            approx_pli->LoadData(relation_);
         else
-            approx_algo_->Fit(data_stream);
+            approx_algo_->LoadData(data_stream);
     }
 }
 

--- a/src/algorithms/typo_miner.h
+++ b/src/algorithms/typo_miner.h
@@ -27,7 +27,7 @@ private:
 
     void ResetState() final;
 
-    void FitInternal(model::IDatasetStream &data_stream) final;
+    void LoadDataInternal(model::IDatasetStream& data_stream) final;
     unsigned long long ExecuteInternal() final;
 
     static bool FDLess(FD const& l, FD const& r);

--- a/tests/test_algorithm.cpp
+++ b/tests/test_algorithm.cpp
@@ -75,9 +75,9 @@ std::set<std::pair<std::vector<unsigned int>, unsigned int>> FDsToSet(std::list<
 TYPED_TEST_SUITE_P(AlgorithmTest);
 
 TYPED_TEST_P(AlgorithmTest, ThrowsOnEmpty) {
-    auto algorithm = TestFixture::CreateAndConfToFit();
+    auto algorithm = TestFixture::CreateAndConfToLoad();
     auto parser = TestFixture::MakeCsvParser(test_data_dir / "TestEmpty.csv", ',', true);
-    ASSERT_THROW(algorithm->Fit(parser), std::runtime_error);
+    ASSERT_THROW(algorithm->LoadData(parser), std::runtime_error);
 }
 
 TYPED_TEST_P(AlgorithmTest, ReturnsEmptyOnSingleNonKey) {

--- a/tests/test_fd_mine.cpp
+++ b/tests/test_fd_mine.cpp
@@ -23,7 +23,7 @@ using std::string, std::vector;
 
 namespace onam = algos::config::names;
 
-std::unique_ptr<FDAlgorithm> ConfToFitFD_Mine() {
+std::unique_ptr<FDAlgorithm> ConfToLoadFD_Mine() {
     std::unique_ptr<FDAlgorithm> algorithm = std::make_unique<Fd_mine>();
     algos::ConfigureFromMap(*algorithm, StdParamsMap{});
     return algorithm;
@@ -85,10 +85,10 @@ std::set<std::pair<std::vector<unsigned int>, unsigned int>> FD_MineFDsToSet(
 }
 
 TEST(AlgorithmSyntheticTest, FD_Mine_ThrowsOnEmpty) {
-    auto algorithm = ConfToFitFD_Mine();
+    auto algorithm = ConfToLoadFD_Mine();
     auto path = test_data_dir / "TestEmpty.csv";
     auto parser = CSVParser(path, ',', true);
-    ASSERT_THROW(algorithm->Fit(parser), std::runtime_error);
+    ASSERT_THROW(algorithm->LoadData(parser), std::runtime_error);
 }
 
 TEST(AlgorithmSyntheticTest, FD_Mine_ReturnsEmptyOnSingleNonKey) {

--- a/tests/test_typo_miner.cpp
+++ b/tests/test_typo_miner.cpp
@@ -72,7 +72,7 @@ struct LinesParam : TestingParam {
           expected(std::move(expected)) {}
 };
 
-static std::unique_ptr<algos::TypoMiner> ConfToFitTypoMiner(
+static std::unique_ptr<algos::TypoMiner> ConfToLoadTypoMiner(
         algos::AlgorithmType const algorithm_type) {
     auto typo_miner = std::make_unique<algos::TypoMiner>(algorithm_type);
     algos::ConfigureFromMap(*typo_miner, algos::StdParamsMap{});
@@ -127,10 +127,10 @@ static void TestForEachAlgo(F&& test) {
 
 TEST(SimpleTypoMinerTest, ThrowsOnEmpty) {
     auto const test = [](algos::AlgorithmType const algo) {
-        auto typo_miner = ConfToFitTypoMiner(algo);
+        auto typo_miner = ConfToLoadTypoMiner(algo);
         auto path = test_data_dir / "TestEmpty.csv";
         auto parser = CSVParser(path, ',', true);
-        ASSERT_THROW(typo_miner->Fit(parser), std::runtime_error);
+        ASSERT_THROW(typo_miner->LoadData(parser), std::runtime_error);
     };
     TestForEachAlgo(test);
 }

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -18,7 +18,7 @@ protected:
         return {path, separator, has_header};
     }
 
-    std::unique_ptr<algos::FDAlgorithm> CreateAndConfToFit() {
+    std::unique_ptr<algos::FDAlgorithm> CreateAndConfToLoad() {
         std::unique_ptr<algos::FDAlgorithm> algorithm = std::make_unique<T>();
         algos::ConfigureFromMap(*algorithm, algos::StdParamsMap{});
         return algorithm;


### PR DESCRIPTION
This was a misnomer. A method in a Python data science library was named `fit`, so that's what ended up here, but this is bound to create more confusion as algorithms aren't necessarily machine learning models that need to be fitted. `LoadData` is more appropriate.