### PR TITLE
Implement parallel version of HyUCC

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ if [[ $NO_TESTS == true ]]; then
   PREFIX="$PREFIX -D COMPILE_TESTS=OFF"
 else
   if [[ ! -d "googletest" ]] ; then
-    git clone https://github.com/google/googletest/ --branch release-1.12.1 --depth 1
+    git clone https://github.com/google/googletest/ --branch v1.13.0 --depth 1
   fi
 fi
 

--- a/src/algorithms/hycommon/all_column_combinations.cpp
+++ b/src/algorithms/hycommon/all_column_combinations.cpp
@@ -7,8 +7,12 @@
 namespace algos::hy {
 
 void AllColumnCombinations::Add(boost::dynamic_bitset<>&& column_set) {
+    Add(column_set);
+}
+
+void AllColumnCombinations::Add(boost::dynamic_bitset<> const& column_set) {
     if (total_ccs_.insert(column_set).second) {
-        new_ccs_.Add(std::move(column_set));
+        new_ccs_.Add(boost::dynamic_bitset<>(column_set));
     }
 }
 

--- a/src/algorithms/hycommon/all_column_combinations.h
+++ b/src/algorithms/hycommon/all_column_combinations.h
@@ -30,6 +30,7 @@ public:
      * @param column_set column combination
      */
     void Add(boost::dynamic_bitset<>&& column_set);
+    void Add(boost::dynamic_bitset<> const& column_set);
 
     /**
      * @return Number of column sets stored in the last-access storage.

--- a/src/algorithms/hycommon/sampler.cpp
+++ b/src/algorithms/hycommon/sampler.cpp
@@ -83,13 +83,15 @@ void Sampler::RunWindow(Efficiency& efficiency, util::PositionListIndex const& p
     unsigned const window = efficiency.GetWindow();
 
     for (util::PLI::Cluster const& cluster : pli.GetIndex()) {
+        boost::dynamic_bitset<> equal_attrs(num_attributes);
         for (size_t i = 0; window < cluster.size() && i < cluster.size() - window; ++i) {
             int const pivot_id = cluster[i];
             int const partner_id = cluster[i + window];
 
-            boost::dynamic_bitset<> equal_attrs(num_attributes);
             Match(equal_attrs, pivot_id, partner_id);
-            agree_sets_->Add(std::move(equal_attrs));
+            assert(equal_attrs.any());
+            agree_sets_->Add(equal_attrs);
+            equal_attrs.reset();
 
             comparisons++;
         }

--- a/src/algorithms/hycommon/sampler.h
+++ b/src/algorithms/hycommon/sampler.h
@@ -31,10 +31,17 @@ private:
     void SortClustersSeq();
     void SortClustersParallel();
     void SortClusters();
+    void InitializeEfficiencyQueueSeq();
+    void InitializeEfficiencyQueueParallel();
+    void InitializeEfficiencyQueueImpl();
     void InitializeEfficiencyQueue();
 
     void Match(boost::dynamic_bitset<>& attributes, size_t first_record_id,
                size_t second_record_id);
+    template <typename F>
+    void RunWindowImpl(Efficiency& efficiency, util::PositionListIndex const& pli, F store_match);
+    std::vector<boost::dynamic_bitset<>> RunWindowRet(Efficiency& efficiency,
+                                                      util::PositionListIndex const& pli);
     void RunWindow(Efficiency& efficiency, util::PositionListIndex const& pli);
 
 public:

--- a/src/algorithms/hycommon/sampler.h
+++ b/src/algorithms/hycommon/sampler.h
@@ -4,11 +4,13 @@
 #include <queue>
 #include <vector>
 
+#include <boost/asio/thread_pool.hpp>
 #include <boost/dynamic_bitset.hpp>
 
 #include "all_column_combinations.h"
 #include "efficiency_threshold.h"
 #include "types.h"
+#include "util/config/thread_number/type.h"
 #include "util/position_list_index.h"
 
 namespace algos::hy {
@@ -21,10 +23,14 @@ private:
     PLIsPtr plis_;
     RowsPtr compressed_records_;
     std::priority_queue<Efficiency> efficiency_queue_;
-
     std::unique_ptr<AllColumnCombinations> agree_sets_;
+    util::config::ThreadNumType threads_num_;
+    std::unique_ptr<boost::asio::thread_pool> pool_;
 
     void ProcessComparisonSuggestions(IdPairs const& comparison_suggestions);
+    void SortClustersSeq();
+    void SortClustersParallel();
+    void SortClusters();
     void InitializeEfficiencyQueue();
 
     void Match(boost::dynamic_bitset<>& attributes, size_t first_record_id,
@@ -32,7 +38,7 @@ private:
     void RunWindow(Efficiency& efficiency, util::PositionListIndex const& pli);
 
 public:
-    Sampler(PLIsPtr plis, RowsPtr pli_records);
+    Sampler(PLIsPtr plis, RowsPtr pli_records, util::config::ThreadNumType threads = 1);
 
     Sampler(Sampler const& other) = delete;
     Sampler(Sampler&& other) = delete;

--- a/src/algorithms/hycommon/validator_helpers.h
+++ b/src/algorithms/hycommon/validator_helpers.h
@@ -46,7 +46,14 @@ void LogLevel(const std::vector<VertexAndAgreeSet>& cur_level_vertices,
 
 template <typename T>
 auto MakeClusterIdentifierToTMap(size_t bucket_size) {
-    auto const kHasher = boost::hash<std::vector<ClusterId>>();
+    auto const kHasher = [](std::vector<ClusterId> const& v) noexcept {
+        size_t hash = 1;
+        for (auto it = v.rbegin(); it != v.rend(); ++it) {
+            hash = 31 * hash + *it;
+        }
+        return hash;
+    };
+
 #if UNORDERED_FLAT_MAP_AVAILABLE
     using UnorderedMap = boost::unordered_flat_map<std::vector<ClusterId>, T, decltype(kHasher)>;
 #else

--- a/src/algorithms/hycommon/validator_helpers.h
+++ b/src/algorithms/hycommon/validator_helpers.h
@@ -6,9 +6,16 @@
 
 #include <boost/container_hash/hash.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <boost/version.hpp>
 #include <easylogging++.h>
 
 #include "types.h"
+
+#define UNORDERED_FLAT_MAP_AVAILABLE (BOOST_VERSION >= 108100)
+
+#if UNORDERED_FLAT_MAP_AVAILABLE
+#include <boost/unordered/unordered_flat_map.hpp>
+#endif
 
 namespace algos::hy {
 
@@ -40,7 +47,14 @@ void LogLevel(const std::vector<VertexAndAgreeSet>& cur_level_vertices,
 template <typename T>
 auto MakeClusterIdentifierToTMap(size_t bucket_size) {
     auto const kHasher = boost::hash<std::vector<ClusterId>>();
-    return std::unordered_map<std::vector<ClusterId>, T, decltype(kHasher)>(bucket_size, kHasher);
+#if UNORDERED_FLAT_MAP_AVAILABLE
+    using UnorderedMap = boost::unordered_flat_map<std::vector<ClusterId>, T, decltype(kHasher)>;
+#else
+    using UnorderedMap = std::unordered_map<std::vector<ClusterId>, T, decltype(kHasher)>;
+#endif
+    return UnorderedMap(bucket_size, kHasher);
 }
+
+#undef UNORDERED_FLAT_MAP_AVAILABLE
 
 }  // namespace algos::hy

--- a/src/algorithms/ucc/hyucc/hyucc.cpp
+++ b/src/algorithms/ucc/hyucc/hyucc.cpp
@@ -33,7 +33,7 @@ unsigned long long HyUCC::ExecuteInternal() {
 
     auto ucc_tree = std::make_unique<UCCTree>(relation_->GetNumColumns());
     Inductor inductor(ucc_tree.get());
-    Validator validator(ucc_tree.get(), plis_shared, pli_records_shared);
+    Validator validator(ucc_tree.get(), plis_shared, pli_records_shared, threads_num_);
 
     IdPairs comparison_suggestions;
 

--- a/src/algorithms/ucc/hyucc/hyucc.cpp
+++ b/src/algorithms/ucc/hyucc/hyucc.cpp
@@ -29,7 +29,7 @@ unsigned long long HyUCC::ExecuteInternal() {
     auto const plis_shared = std::make_shared<PLIs>(std::move(plis));
     auto const pli_records_shared = std::make_shared<Rows>(std::move(pli_records));
 
-    hyucc::Sampler sampler(plis_shared, pli_records_shared);
+    hyucc::Sampler sampler(plis_shared, pli_records_shared, threads_num_);
 
     auto ucc_tree = std::make_unique<UCCTree>(relation_->GetNumColumns());
     Inductor inductor(ucc_tree.get());

--- a/src/algorithms/ucc/hyucc/hyucc.h
+++ b/src/algorithms/ucc/hyucc/hyucc.h
@@ -6,21 +6,29 @@
 #include "model/column_layout_relation_data.h"
 #include "model/idataset_stream.h"
 #include "ucc/ucc_algorithm.h"
+#include "util/config/thread_number/option.h"
+#include "util/config/thread_number/type.h"
 
 namespace algos {
 
 class HyUCC : public UCCAlgorithm {
 private:
     std::unique_ptr<ColumnLayoutRelationData> relation_;
+    util::config::ThreadNumType threads_num_ = 1;
 
     void LoadDataInternal(model::IDatasetStream& data_stream) override;
     unsigned long long ExecuteInternal() override;
     void ResetUCCAlgorithmState() override {}
     void RegisterUCCs(std::vector<boost::dynamic_bitset<>>&& uccs,
                       const std::vector<hy::ClusterId>& og_mapping);
+    void MakeExecuteOptsAvailable() final {
+        MakeOptionsAvailable({util::config::ThreadNumberOpt.GetName()});
+    }
 
 public:
-    HyUCC() : UCCAlgorithm({}) {}
+    HyUCC() : UCCAlgorithm({}) {
+        RegisterOption(util::config::ThreadNumberOpt(&threads_num_));
+    }
 };
 
 }  // namespace algos

--- a/src/algorithms/ucc/hyucc/sampler.h
+++ b/src/algorithms/ucc/hyucc/sampler.h
@@ -3,6 +3,7 @@
 #include "hycommon/sampler.h"
 #include "hycommon/types.h"
 #include "ucc/hyucc/structures/non_ucc_list.h"
+#include "util/config/thread_number/type.h"
 
 namespace algos::hyucc {
 
@@ -11,8 +12,8 @@ private:
     hy::Sampler sampler_;
 
 public:
-    Sampler(hy::PLIsPtr plis, hy::RowsPtr pli_records)
-        : sampler_(std::move(plis), std::move(pli_records)) {}
+    Sampler(hy::PLIsPtr plis, hy::RowsPtr pli_records, util::config::ThreadNumType threads = 1)
+        : sampler_(std::move(plis), std::move(pli_records), threads) {}
 
     NonUCCList GetNonUCCs(hy::IdPairs const& comparison_suggestions) {
         return sampler_.GetAgreeSets(comparison_suggestions);

--- a/src/algorithms/ucc/hyucc/validator.h
+++ b/src/algorithms/ucc/hyucc/validator.h
@@ -4,11 +4,14 @@
 #include <utility>
 #include <vector>
 
+#include <boost/asio/thread_pool.hpp>
+
 #include "hycommon/primitive_validations.h"
 #include "hycommon/types.h"
 #include "model/raw_ucc.h"
 #include "position_list_index.h"
 #include "structures/ucc_tree.h"
+#include "util/config/thread_number/type.h"
 
 namespace algos::hyucc {
 
@@ -20,15 +23,22 @@ private:
     hy::PLIsPtr plis_;
     hy::RowsPtr compressed_records_;
     unsigned current_level_number_ = 1;
+    util::config::ThreadNumType threads_num_ = 1;
 
     bool IsUnique(util::PLI const& pivot_pli, model::RawUCC const& ucc,
                   hy::IdPairs& comparison_suggestions);
     UCCValidations GetValidations(LhsPair const& vertex_and_ucc);
     UCCValidations ValidateAndExtendSeq(std::vector<LhsPair> const& current_level);
+    UCCValidations ValidateAndExtendParallel(std::vector<LhsPair> const& current_level);
+    UCCValidations ValidateAndExtend(std::vector<LhsPair> const& current_level);
 
 public:
-    Validator(UCCTree* tree, hy::PLIsPtr plis, hy::RowsPtr compressed_records) noexcept
-        : tree_(tree), plis_(std::move(plis)), compressed_records_(std::move(compressed_records)) {}
+    Validator(UCCTree* tree, hy::PLIsPtr plis, hy::RowsPtr compressed_records,
+              util::config::ThreadNumType threads_num) noexcept
+        : tree_(tree),
+          plis_(std::move(plis)),
+          compressed_records_(std::move(compressed_records)),
+          threads_num_(threads_num) {}
 
     hy::IdPairs ValidateAndExtendCandidates();
 };


### PR DESCRIPTION
Implements multithreaded version of HyUCC with `Validator` parallelized and with initialization step of `Sampler` parallelized. Also adds tests for multithreaded UCC algorithms. 
`Sampler` is the same for HyUCC and HyFD, but before using it in HyFD we should check how parallelized `Sampler` version performs for HyFD.