### PR TITLE
Implement HyUCC Python bindings

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -3,4 +3,9 @@ SET(BINDINGS_NAME desbordante)
 file(GLOB_RECURSE sources "*.h*" "*.cpp*")
 pybind11_add_module(${BINDINGS_NAME} ${sources})
 
-target_link_libraries(${BINDINGS_NAME} PRIVATE ${CMAKE_PROJECT_NAME}_lib easyloggingpp)
+# TODO(polyntsov): Explicitly link with the shared library, static won't work.
+# This solution seems ugly since I don't fully understand which part of the python bindings library
+# uses Boost::thread, but without it `import desbordante` will crash with undefined symbol error.
+# We need to investigate the problem and remove the dependency on Boost::thread
+find_library(BOOST_THREAD libboost_thread.so libboost_thread)
+target_link_libraries(${BINDINGS_NAME} PRIVATE ${CMAKE_PROJECT_NAME}_lib easyloggingpp ${BOOST_THREAD})

--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -41,6 +41,7 @@
 #include "py_fd_algorithm.h"
 #include "py_fd_verifier.h"
 #include "py_metric_verifier.h"
+#include "py_ucc_algorithm.h"
 
 INITIALIZE_EASYLOGGINGPP
 
@@ -49,11 +50,14 @@ INITIALIZE_EASYLOGGINGPP
 #define DEFINE_ALGORITHM_BASE(base) py::class_<Py##base##Base, PyAlgorithmBase>(module, #base)
 #define DEFINE_FD_ALGORITHM(type) DEFINE_ALGORITHM(type, FdAlgorithm)
 #define DEFINE_AR_ALGORITHM(type) DEFINE_ALGORITHM(type, ArAlgorithm)
+#define DEFINE_UCC_ALGORITHM(type) DEFINE_ALGORITHM(type, UCCAlgorithm)
 
 namespace python_bindings {
 
 namespace py = pybind11;
+// AR mining algorithms
 using PyApriori = PyArAlgorithm<algos::Apriori>;
+// FD mining algorithms
 using PyTane = PyFDAlgorithm<algos::Tane>;
 using PyPyro = PyFDAlgorithm<algos::Pyro>;
 using PyFUN = PyFDAlgorithm<algos::FUN>;
@@ -64,6 +68,9 @@ using PyFDep = PyFDAlgorithm<algos::FDep>;
 using PyDFD = PyFDAlgorithm<algos::DFD>;
 using PyDepminer = PyFDAlgorithm<algos::Depminer>;
 using PyAid = PyFDAlgorithm<algos::Aid>;
+// UCC mining algorithms
+using PyHyUCC = PyUCCAlgorithm<algos::HyUCC>;
+
 using FDHighlight = algos::fd_verifier::Highlight;
 using model::ARStrings;
 
@@ -92,6 +99,11 @@ PYBIND11_MODULE(desbordante, module) {
             .def_property_readonly("lhs_indices", &PyFD::GetLhs)
             .def_property_readonly("rhs_index", &PyFD::GetRhs);
 
+    py::class_<PyUCC>(module, "UCC")
+            .def("__str__", &PyUCC::ToString)
+            .def("__repr__", &PyUCC::ToString)
+            .def_property_readonly("indices", &PyUCC::GetUCC);
+
     py::class_<FDHighlight>(module, "FDHighlight")
             .def_property_readonly("cluster", &FDHighlight::GetCluster)
             .def_property_readonly("num_distinct_rhs_values", &FDHighlight::GetNumDistinctRhsValues)
@@ -117,6 +129,7 @@ PYBIND11_MODULE(desbordante, module) {
 
     DEFINE_ALGORITHM_BASE(ArAlgorithm).def("get_ars", &PyArAlgorithmBase::GetARs);
     DEFINE_ALGORITHM_BASE(FdAlgorithm).def("get_fds", &PyFdAlgorithmBase::GetFDs);
+    DEFINE_ALGORITHM_BASE(UCCAlgorithm).def("get_uccs", &PyUCCAlgorithmBase::GetUCCs);
 
     DEFINE_ALGORITHM(FDVerifier, Algorithm)
             .def("fd_holds", &PyFDVerifier::FDHolds)
@@ -141,9 +154,12 @@ PYBIND11_MODULE(desbordante, module) {
     DEFINE_FD_ALGORITHM(HyFD);
     DEFINE_FD_ALGORITHM(Pyro);
     DEFINE_FD_ALGORITHM(Tane);
+
+    DEFINE_UCC_ALGORITHM(HyUCC);
 }
 #undef DEFINE_FD_ALGORITHM
 #undef DEFINE_AR_ALGORITHM
+#undef DEFINE_UCC_ALGORITHM
 #undef DEFINE_ALGORITHM_BASE
 #undef DEFINE_ALGORITHM
 

--- a/python_bindings/py_fd.cpp
+++ b/python_bindings/py_fd.cpp
@@ -2,14 +2,13 @@
 
 #include <sstream>
 
+#include "util/bitset_utils.h"
+
 namespace python_bindings {
 
-PyFD::PyFD(RawFD const& fd) : rhs_index_(fd.rhs_) {
-    for (size_t index = fd.lhs_.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = fd.lhs_.find_next(index)) {
-        lhs_indices_.emplace_back(index);
-    }
-}
+PyFD::PyFD(RawFD const& fd)
+    : lhs_indices_(util::BitsetToIndices<decltype(lhs_indices_)::value_type>(fd.lhs_)),
+      rhs_index_(fd.rhs_) {}
 
 std::string PyFD::ToString() const {
     std::stringstream stream;

--- a/python_bindings/py_fd.h
+++ b/python_bindings/py_fd.h
@@ -22,7 +22,7 @@ public:
         return rhs_index_;
     }
 
-    [[nodiscard]] util::config::IndicesType GetLhs() const {
+    [[nodiscard]] util::config::IndicesType const& GetLhs() const noexcept {
         return lhs_indices_;
     }
 };

--- a/python_bindings/py_ucc.cpp
+++ b/python_bindings/py_ucc.cpp
@@ -1,0 +1,22 @@
+#include "py_ucc.h"
+
+#include <sstream>
+
+#include "util/bitset_utils.h"
+
+namespace python_bindings {
+
+PyUCC::PyUCC(model::RawUCC const& raw_ucc)
+    : ucc_indices_(util::BitsetToIndices<util::config::IndexType>(raw_ucc)) {}
+
+std::string PyUCC::ToString() const {
+    std::stringstream stream;
+    stream << "( ";
+    for (util::config::IndexType index : ucc_indices_) {
+        stream << index << " ";
+    }
+    stream << ")";
+    return stream.str();
+}
+
+}  // namespace python_bindings

--- a/python_bindings/py_ucc.h
+++ b/python_bindings/py_ucc.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "model/raw_ucc.h"
+#include "model/ucc.h"
+#include "util/config/indices/type.h"
+
+namespace python_bindings {
+
+class PyUCC {
+private:
+    util::config::IndicesType ucc_indices_;
+
+public:
+    explicit PyUCC(model::RawUCC const& raw_ucc);
+    explicit PyUCC(model::UCC const& ucc) : PyUCC(ucc.GetColumnIndices()) {}
+
+    [[nodiscard]] std::string ToString() const;
+
+    [[nodiscard]] util::config::IndicesType const& GetUCC() const noexcept {
+        return ucc_indices_;
+    }
+};
+
+}  // namespace python_bindings

--- a/python_bindings/py_ucc_algorithm.h
+++ b/python_bindings/py_ucc_algorithm.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <list>
+
+#include "algorithms/ucc/ucc_algorithm.h"
+#include "get_algorithm.h"
+#include "model/ucc.h"
+#include "py_algorithm.h"
+#include "py_ucc.h"
+
+namespace python_bindings {
+
+class PyUCCAlgorithmBase : public PyAlgorithmBase {
+protected:
+    using PyAlgorithmBase::PyAlgorithmBase;
+
+public:
+    [[nodiscard]] std::vector<PyUCC> GetUCCs() const {
+        auto const& ucc_algo = GetAlgorithm<algos::UCCAlgorithm>(algorithm_);
+        std::list<model::UCC> const& ucc_list = ucc_algo.UCCList();
+        std::vector<PyUCC> py_uccs;
+        py_uccs.reserve(ucc_list.size());
+
+        for (model::UCC const& ucc : ucc_list) {
+            py_uccs.emplace_back(ucc);
+        }
+
+        return py_uccs;
+    }
+};
+
+template <typename T>
+using PyUCCAlgorithm = PyAlgorithm<T, PyUCCAlgorithmBase>;
+
+}  // namespace python_bindings

--- a/src/algorithms/hycommon/sampler.h
+++ b/src/algorithms/hycommon/sampler.h
@@ -4,7 +4,6 @@
 #include <queue>
 #include <vector>
 
-#include <boost/asio/thread_pool.hpp>
 #include <boost/dynamic_bitset.hpp>
 
 #include "all_column_combinations.h"
@@ -12,6 +11,12 @@
 #include "types.h"
 #include "util/config/thread_number/type.h"
 #include "util/position_list_index.h"
+
+namespace boost::asio {
+// Forward declare thread_pool to avoid including boost::asio::thread_pool implementation since
+// it's not needed here and to avoid transitevly pollute all other files with it
+class thread_pool;
+}  // namespace boost::asio
 
 namespace algos::hy {
 

--- a/src/algorithms/ucc/hyucc/validator.h
+++ b/src/algorithms/ucc/hyucc/validator.h
@@ -4,8 +4,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/asio/thread_pool.hpp>
-
 #include "hycommon/primitive_validations.h"
 #include "hycommon/types.h"
 #include "model/raw_ucc.h"

--- a/src/util/bitset_utils.h
+++ b/src/util/bitset_utils.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <boost/dynamic_bitset.hpp>
 
 namespace util {


### PR DESCRIPTION
This PR implements python bindings for the HyUCC algorithm. 
It also fixes a problem introduced in #220 (commit 6cd9f98e8341f9460abb21b02a60aa233487184a). Somehow this commit despite not touching python bindings in any way makes desbordante shared library with python bindings dependent on the `Boost::thread`. That is, `import desbordante` crashes with the error "undefined symbol to _ZN5boost11this_thread18interruption_pointEv" if it wasn't linked with the `Boost::thread`. However, the fix (the linkage) is temporary, I think python bindings has nothing to do with `Boost::thread` (at least for now) and thus bindings shouldn't be linked with it. Instead, we should  find and remove this inexplicable dependency