### PR TITLE
CMakeLists and workflow cleanup

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/cache@v3
       id: cache-datasets
       with:
-        path: ${{github.workspace}}/datasets
+        path: ${{github.workspace}}/datasets/datasets.zip
         key: ${{ runner.os }}datasets
     - name: Pull datasets
       run: bash pull_datasets.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
 endif()
 
 # configuring boost
-set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_LIBS OFF)
 find_package(Boost 1.72.0 REQUIRED COMPONENTS container program_options thread)
 include_directories(${Boost_INCLUDE_DIRS})
 message(${Boost_INCLUDE_DIRS})

--- a/datasets/CMakeLists.txt
+++ b/datasets/CMakeLists.txt
@@ -1,13 +1,21 @@
-# unzip heavy datasets - TODO: not a cross-platform command, works only for Linux
-add_custom_target( unZip ALL ) 
+add_custom_target(make-input-data-dir ALL)
+add_custom_command(
+	TARGET make-input-data-dir
+	COMMAND ${CMAKE_COMMAND} -E make_directory
+		${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/input_data/
+)
+
+add_custom_target( unZip ALL )
 add_custom_command(
 	TARGET unZip
 	COMMAND ${CMAKE_COMMAND} -E tar xzf
 		${CMAKE_SOURCE_DIR}/datasets/datasets.zip
-	DEPENDS 
+	DEPENDS
 		${CMAKE_SOURCE_DIR}/datasets/datasets.zip
-	WORKING_DIRECTORY 
+	WORKING_DIRECTORY
 		${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/input_data/
 	COMMENT "Unpacking datasets.zip"
 	VERBATIM
 )
+
+add_dependencies(unZip make-input-data-dir)

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -3,9 +3,4 @@ SET(BINDINGS_NAME desbordante)
 file(GLOB_RECURSE sources "*.h*" "*.cpp*")
 pybind11_add_module(${BINDINGS_NAME} ${sources})
 
-# TODO(polyntsov): Explicitly link with the shared library, static won't work.
-# This solution seems ugly since I don't fully understand which part of the python bindings library
-# uses Boost::thread, but without it `import desbordante` will crash with undefined symbol error.
-# We need to investigate the problem and remove the dependency on Boost::thread
-find_library(BOOST_THREAD libboost_thread.so libboost_thread)
-target_link_libraries(${BINDINGS_NAME} PRIVATE ${CMAKE_PROJECT_NAME}_lib easyloggingpp ${BOOST_THREAD})
+target_link_libraries(${BINDINGS_NAME} PRIVATE ${CMAKE_PROJECT_NAME}_lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,8 +2,13 @@ set(BINARY ${CMAKE_PROJECT_NAME})
 
 file(GLOB_RECURSE lib_sources "*/*.h*" "*/*.cpp*" "*/*.cc*")
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 add_library(${BINARY}_lib STATIC ${lib_sources})
 set_property(TARGET ${BINARY}_lib PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(${BINARY}_lib PRIVATE ${Boost_LIBRARIES} Threads::Threads)
+target_link_libraries(${BINARY}_lib PUBLIC easyloggingpp)
 
 option(SAFE_VERTICAL_HASHING
         "Enable safe vertical hashing. This feature allows to process\
@@ -15,9 +20,5 @@ endif(SAFE_VERTICAL_HASHING)
 
 set(run_sources "main.cpp")
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
 add_executable(${BINARY}_run ${run_sources})
-target_link_libraries(${BINARY}_run PUBLIC ${CMAKE_PROJECT_NAME}_lib)
-target_link_libraries(${BINARY}_run LINK_PUBLIC ${Boost_LIBRARIES} Threads::Threads easyloggingpp)
-
+target_link_libraries(${BINARY}_run PRIVATE ${CMAKE_PROJECT_NAME}_lib)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,8 +9,7 @@ add_executable(${BINARY} ${test_sources})
 add_test(NAME ${BINARY} COMMAND ${BINARY})
 
 # linking with gtest and implemented classes
-target_link_libraries(${BINARY} PUBLIC ${CMAKE_PROJECT_NAME}_lib)
-target_link_libraries(${BINARY} LINK_PUBLIC gtest gmock Boost::thread easyloggingpp)
+target_link_libraries(${BINARY} PRIVATE ${CMAKE_PROJECT_NAME}_lib gtest gmock)
 
 # copying sample csv's for testing
 add_custom_target(copy-files ALL


### PR DESCRIPTION
Fixes build failure when doing a clean build without tests.
Only `datasets/datasets.zip` is now cached instead of `datasets/` (`datasets/CMakeLists.txt` is no longer cached).

Boost is linked straight to the main library, easyloggingpp is publicly linked to the main library. Changes Boost's linking to dynamic so that there are no issues with building python bindings if the user's static Boost is not built with `-fPIC`.