### PR TITLE
Python bindings cleanup

### DIFF
--- a/python_bindings/bindings.cpp
+++ b/python_bindings/bindings.cpp
@@ -43,6 +43,7 @@
 #include "py_fd_verifier.h"
 #include "py_metric_verifier.h"
 #include "py_ucc_algorithm.h"
+#include "util/config/tabular_data/input_table_type.h"
 
 INITIALIZE_EASYLOGGINGPP
 
@@ -89,6 +90,8 @@ PYBIND11_MODULE(desbordante, module) {
     }
 
     module.doc() = "A data profiling library";
+
+    py::class_<util::config::InputTable>(module, "Table");
 
     py::class_<ARStrings>(module, "AssociativeRule")
             .def("__str__", &ARStrings::ToString)

--- a/python_bindings/create_dataframe_reader.cpp
+++ b/python_bindings/create_dataframe_reader.cpp
@@ -24,7 +24,7 @@ static bool AllColumnsAreStrings(py::handle dataframe) {
 }
 
 util::config::InputTable CreateDataFrameReader(py::handle dataframe, std::string name) {
-    if (!IsDataFrame(dataframe)) throw py::type_error("Passed object is not a dataframe");
+    if (!IsDataFrame(dataframe)) throw std::invalid_argument("Passed object is not a dataframe");
     if (AllColumnsAreStrings(dataframe)) {
         return std::make_shared<StringDataframeReader>(dataframe, std::move(name));
     } else {

--- a/python_bindings/get_py_type.cpp
+++ b/python_bindings/get_py_type.cpp
@@ -22,6 +22,10 @@ constexpr PyTypeObject* const py_str = &PyUnicode_Type;
 constexpr PyTypeObject* const py_list = &PyList_Type;
 constexpr PyTypeObject* const py_tuple = &PyTuple_Type;
 
+py::handle MakeType(py::type type) {
+    return type;
+}
+
 py::handle MakeType(PyTypeObject* py_type_ptr) {
     // Does the same as `&py_type_ptr->ob_base.ob_base`: Python API simulates
     // inheritance here. There is also the `_PyObject_CAST` macro that does a
@@ -40,51 +44,35 @@ py::tuple MakeTypeTuple(TypePtrs... type_ptrs) {
 }
 
 template <typename CppType, PyTypeObject*... PyTypes>
-std::pair<std::type_index, std::function<py::frozenset()>> const SimplePyTypeInfoPair{
-        std::type_index{typeid(CppType)},
-        []() { return py::frozenset{py::make_tuple(MakeTypeTuple(PyTypes...))}; }};
-
-py::frozenset GetPyInputTableType() {
-    std::vector<py::tuple> types;
-    try {
-        PyObject* df_type = py::module::import("pandas").attr("DataFrame").ptr();
-        types = {MakeTypeTuple(df_type), MakeTypeTuple(py_tuple, df_type, py_str),
-                 MakeTypeTuple(py_tuple, py_str, py_str, py_bool)};
-    } catch (py::error_already_set& e) {
-        if (e.matches(PyExc_ImportError)) {
-            types = {MakeTypeTuple(py_tuple, py_str, py_str, py_bool)};
-        } else {
-            throw;
-        }
-    }
-    return {py::make_iterator(types.begin(), types.end())};
-}
+std::pair<std::type_index, std::function<py::tuple()>> const PyTypePair{
+        std::type_index{typeid(CppType)}, []() { return MakeTypeTuple(PyTypes...); }};
 
 }  // namespace
 
 namespace python_bindings {
 
-py::frozenset GetPyType(std::type_index type_index) {
-    // Type indexes are mapped to frozensets of Python type tuples. The first
-    // element of all the tuples is the type of the parameter itself. If that
-    // element is `list`, the following element denotes the type of its
-    // elements. If that parameter is `tuple` then the following parameters
-    // denote the types of their respective elements.
+py::tuple GetPyType(std::type_index type_index) {
+    // Type indexes are mapped to Python type tuples. The first element of all
+    // the tuples is the type of the parameter itself. If that element is
+    // `list`, the following element denotes the type of its elements. If that
+    // parameter is `tuple` then the following parameters denote the types of
+    // their respective elements.
     // The tuples are created at runtime from Python API's raw pointers (when
     // possible) as storing pybind11's objects themselves statically is
     // unpredictable and can lead to errors related to garbage collection.
-    static const std::unordered_map<std::type_index, std::function<py::frozenset()>> type_map{
-            SimplePyTypeInfoPair<bool, py_bool>,
-            SimplePyTypeInfoPair<ushort, py_int>,
-            SimplePyTypeInfoPair<int, py_int>,
-            SimplePyTypeInfoPair<unsigned int, py_int>,
-            SimplePyTypeInfoPair<double, py_float>,
-            SimplePyTypeInfoPair<long double, py_float>,
-            SimplePyTypeInfoPair<algos::metric::Metric, py_str>,
-            SimplePyTypeInfoPair<algos::metric::MetricAlgo, py_str>,
-            SimplePyTypeInfoPair<algos::InputFormat, py_str>,
-            SimplePyTypeInfoPair<std::vector<unsigned int>, py_list, py_int>,
-            {typeid(util::config::InputTable), GetPyInputTableType},
+    static const std::unordered_map<std::type_index, std::function<py::tuple()>> type_map{
+            PyTypePair<bool, py_bool>,
+            PyTypePair<ushort, py_int>,
+            PyTypePair<int, py_int>,
+            PyTypePair<unsigned int, py_int>,
+            PyTypePair<double, py_float>,
+            PyTypePair<long double, py_float>,
+            PyTypePair<algos::metric::Metric, py_str>,
+            PyTypePair<algos::metric::MetricAlgo, py_str>,
+            PyTypePair<algos::InputFormat, py_str>,
+            PyTypePair<std::vector<unsigned int>, py_list, py_int>,
+            {typeid(util::config::InputTable),
+             []() { return MakeTypeTuple(py::type::of<util::config::InputTable>()); }},
     };
     return type_map.at(type_index)();
 }

--- a/python_bindings/get_py_type.cpp
+++ b/python_bindings/get_py_type.cpp
@@ -15,12 +15,12 @@ namespace py = pybind11;
 
 namespace {
 
-constexpr static PyTypeObject* const py_int = &PyLong_Type;
-constexpr static PyTypeObject* const py_bool = &PyBool_Type;
-constexpr static PyTypeObject* const py_float = &PyFloat_Type;
-constexpr static PyTypeObject* const py_str = &PyUnicode_Type;
-constexpr static PyTypeObject* const py_list = &PyList_Type;
-constexpr static PyTypeObject* const py_tuple = &PyTuple_Type;
+constexpr PyTypeObject* const py_int = &PyLong_Type;
+constexpr PyTypeObject* const py_bool = &PyBool_Type;
+constexpr PyTypeObject* const py_float = &PyFloat_Type;
+constexpr PyTypeObject* const py_str = &PyUnicode_Type;
+constexpr PyTypeObject* const py_list = &PyList_Type;
+constexpr PyTypeObject* const py_tuple = &PyTuple_Type;
 
 py::handle MakeType(PyTypeObject* py_type_ptr) {
     // Does the same as `&py_type_ptr->ob_base.ob_base`: Python API simulates

--- a/python_bindings/get_py_type.h
+++ b/python_bindings/get_py_type.h
@@ -5,5 +5,5 @@
 #include <pybind11/pybind11.h>
 
 namespace python_bindings {
-pybind11::frozenset GetPyType(std::type_index type_index);
+pybind11::tuple GetPyType(std::type_index type_index);
 }  // namespace python_bindings

--- a/python_bindings/py_algorithm.cpp
+++ b/python_bindings/py_algorithm.cpp
@@ -37,7 +37,7 @@ void PyAlgorithmBase::Configure(py::kwargs const& kwargs, InputTable table) {
                 std::type_index type_index = algorithm_->GetTypeIndex(option_name);
                 assert(type_index != void_index);
                 return kwargs.contains(option_name)
-                               ? PyToAny(type_index, kwargs[py::str{option_name}])
+                               ? PyToAny(option_name, type_index, kwargs[py::str{option_name}])
                                : boost::any{};
             });
 }
@@ -47,8 +47,8 @@ void PyAlgorithmBase::SetOption(std::string_view option_name, py::handle option_
         algorithm_->SetOption(option_name);
         return;
     }
-    algorithm_->SetOption(option_name,
-                          PyToAny(algorithm_->GetTypeIndex(option_name), option_value));
+    algorithm_->SetOption(
+            option_name, PyToAny(option_name, algorithm_->GetTypeIndex(option_name), option_value));
 }
 
 std::unordered_set<std::string_view> PyAlgorithmBase::GetNeededOptions() const {

--- a/python_bindings/py_algorithm.cpp
+++ b/python_bindings/py_algorithm.cpp
@@ -55,7 +55,7 @@ std::unordered_set<std::string_view> PyAlgorithmBase::GetNeededOptions() const {
     return algorithm_->GetNeededOptions();
 }
 
-py::frozenset PyAlgorithmBase::GetOptionType(std::string_view option_name) const {
+py::tuple PyAlgorithmBase::GetOptionType(std::string_view option_name) const {
     auto type_index = algorithm_->GetTypeIndex(option_name);
     if (type_index == void_index)
         throw std::invalid_argument{std::string{"Option named \""} + option_name.data() +

--- a/python_bindings/py_algorithm.h
+++ b/python_bindings/py_algorithm.h
@@ -28,7 +28,7 @@ public:
 
     [[nodiscard]] std::unordered_set<std::string_view> GetNeededOptions() const;
 
-    [[nodiscard]] pybind11::frozenset GetOptionType(std::string_view option_name) const;
+    [[nodiscard]] pybind11::tuple GetOptionType(std::string_view option_name) const;
 
     // For pandas dataframes
     void LoadData(pybind11::handle dataframe, std::string name, pybind11::kwargs const& kwargs);

--- a/python_bindings/py_to_any.cpp
+++ b/python_bindings/py_to_any.cpp
@@ -2,6 +2,7 @@
 #include <unordered_map>
 
 #include <boost/any.hpp>
+#include <easylogging++.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -10,43 +11,89 @@
 #include "algorithms/metric/enums.h"
 #include "create_dataframe_reader.h"
 #include "csv_parser.h"
+#include "util/config/enum_to_available_values.h"
 #include "util/config/tabular_data/input_table_type.h"
 
-namespace python_bindings {
-namespace py = pybind11;
-using ConvFunc = std::function<boost::any(py::handle)>;
+namespace {
 
-static util::config::InputTable CreateCsvParser(py::tuple const& arguments) {
-    if (py::len(arguments) != 3) {
-        throw py::value_error("Cannot create a csv parser from passed tuple.");
+namespace py = pybind11;
+using ConvFunc = std::function<boost::any(std::string_view, py::handle)>;
+
+template <typename T>
+T CastAndReplaceCastError(std::string_view option_name, py::handle value) {
+    try {
+        return py::cast<T>(value);
+    } catch (py::cast_error& e) {
+        throw std::invalid_argument(
+                std::string("Unable to cast Python object to C++ type for option \"") +
+                option_name.data() + '"');
     }
-    return std::make_shared<CSVParser>(py::cast<std::string>(arguments[0]),
-                                       py::cast<char>(arguments[1]), py::cast<bool>(arguments[2]));
+}
+
+util::config::InputTable CreateCsvParser(std::string_view option_name, py::tuple const& arguments) {
+    if (py::len(arguments) != 3) {
+        throw std::invalid_argument("Cannot create a csv parser from passed tuple.");
+    }
+
+    return std::make_shared<CSVParser>(
+            CastAndReplaceCastError<std::string>(option_name, arguments[0]),
+            CastAndReplaceCastError<char>(option_name, arguments[1]),
+            CastAndReplaceCastError<bool>(option_name, arguments[2]));
 }
 
 template <typename Type>
-static std::pair<std::type_index, ConvFunc> const NormalConvPair{
-        std::type_index(typeid(Type)), [](py::handle value) { return py::cast<Type>(value); }};
-
-template <typename EnumType>
-static std::pair<std::type_index, ConvFunc> const EnumConvPair{
-        std::type_index(typeid(EnumType)), [](py::handle value) {
-            return EnumType::_from_string_nocase(py::cast<std::string>(value).data());
+std::pair<std::type_index, ConvFunc> const NormalConvPair{
+        std::type_index(typeid(Type)), [](std::string_view option_name, py::handle value) {
+            return CastAndReplaceCastError<Type>(option_name, value);
         }};
 
 template <typename EnumType>
-static std::pair<std::type_index, ConvFunc> const CharEnumConvPair{
-        std::type_index(typeid(EnumType)),
-        [](py::handle value) { return EnumType::_from_integral(py::cast<char>(value)); }};
+std::pair<std::type_index, ConvFunc> const EnumConvPair{
+        std::type_index(typeid(EnumType)), [](std::string_view option_name, py::handle value) {
+            auto string = CastAndReplaceCastError<std::string>(option_name, value);
+            better_enums::optional<EnumType> enum_holder =
+                    EnumType::_from_string_nocase_nothrow(string.data());
+            if (enum_holder) return *enum_holder;
 
-static boost::any InputTableToAny(py::handle obj) {
+            std::stringstream error_message;
+            error_message << "Incorrect value for option \"" << option_name
+                          << "\". Possible values: " << util::EnumToAvailableValues<EnumType>();
+            throw std::invalid_argument(error_message.str());
+        }};
+
+template <typename EnumType>
+std::pair<std::type_index, ConvFunc> const CharEnumConvPair{
+        std::type_index(typeid(EnumType)), [](std::string_view option_name, py::handle value) {
+            using EnumValueType = typename EnumType::_integral;
+            // May be applicable to other types.
+            static_assert(std::is_same_v<EnumValueType, char>);
+            auto char_value = CastAndReplaceCastError<char>(option_name, value);
+            better_enums::optional<EnumType> enum_holder =
+                    EnumType::_from_integral_nothrow(char_value);
+            if (enum_holder) return *enum_holder;
+
+            std::stringstream error_message;
+            error_message << "Incorrect value for option \"" << option_name
+                          << "\". Possible values: ";
+
+            error_message << '[';
+            for (auto const& val : EnumType::_values()) {
+                error_message << val._to_integral() << '|';
+            }
+            error_message.seekp(-1, std::stringstream::cur);
+            error_message << ']';
+
+            throw std::invalid_argument(error_message.str());
+        }};
+
+boost::any InputTableToAny(std::string_view option_name, py::handle obj) {
     if (py::isinstance<py::tuple>(obj)) {
-        return CreateCsvParser(py::cast<py::tuple>(obj));
+        return CreateCsvParser(option_name, py::cast<py::tuple>(obj));
     }
-    return CreateDataFrameReader(obj);
+    return python_bindings::CreateDataFrameReader(obj);
 }
 
-static const std::unordered_map<std::type_index, ConvFunc> converters{
+const std::unordered_map<std::type_index, ConvFunc> converters{
         NormalConvPair<bool>,
         NormalConvPair<double>,
         NormalConvPair<unsigned int>,
@@ -62,8 +109,12 @@ static const std::unordered_map<std::type_index, ConvFunc> converters{
         {typeid(util::config::InputTable), InputTableToAny},
 };
 
-boost::any PyToAny(std::type_index index, py::handle obj) {
-    return converters.at(index)(obj);
+}  // namespace
+
+namespace python_bindings {
+
+boost::any PyToAny(std::string_view option_name, std::type_index index, py::handle obj) {
+    return converters.at(index)(option_name, obj);
 }
 
 }  // namespace python_bindings

--- a/python_bindings/py_to_any.h
+++ b/python_bindings/py_to_any.h
@@ -4,5 +4,6 @@
 #include <pybind11/pybind11.h>
 
 namespace python_bindings {
-[[nodiscard]] boost::any PyToAny(std::type_index index, pybind11::handle obj);
+[[nodiscard]] boost::any PyToAny(std::string_view option_name, std::type_index index,
+                                 pybind11::handle obj);
 }  // namespace python_bindings


### PR DESCRIPTION
Changes according to feedback.

Better error messages for cast failures.

`get_option_type` returns a tuple denoting an option's type that is meant to be unpacked as `main_type, *args = algo.get_option_type("name")`