### PR TITLE
Add an algo tuple assertion

### DIFF
--- a/src/algorithms/algorithm_types.h
+++ b/src/algorithms/algorithm_types.h
@@ -54,4 +54,8 @@ BETTER_ENUM(AlgorithmType, char,
 )
 // clang-format on
 
+static_assert(std::tuple_size_v<AlgorithmTypes> == AlgorithmType::_size(),
+              "The AlgorithmTypes tuple and the AlgorithmType enum sizes must be the same. Did you "
+              "forget to add your new algorithm to either of those?");
+
 }  // namespace algos

--- a/src/algorithms/create_algorithm.h
+++ b/src/algorithms/create_algorithm.h
@@ -6,11 +6,6 @@
 
 namespace algos {
 
-using AlgorithmTypes =
-        std::tuple<Depminer, DFD, FastFDs, FDep, Fd_mine, Pyro, Tane, FUN, hyfd::HyFD, Aid, Apriori,
-                   metric::MetricVerifier, DataStats, fd_verifier::FDVerifier, HyUCC,
-                   cfd::FDFirstAlgorithm, ACAlgorithm>;
-
 template <typename AlgorithmBase = Algorithm>
 std::unique_ptr<AlgorithmBase> CreateAlgorithmInstance(AlgorithmType algorithm) {
     auto const create = [](auto I) -> std::unique_ptr<AlgorithmBase> {


### PR DESCRIPTION
If a person new to the project did not add an algorithm to both the type tuple and the enum, it would lead to a confusing error message. This makes compilation fail with a clearer error message.