### PR TITLE
Implemented conversion mechanism from model::INumericType

### DIFF
--- a/src/model/types/cast/cast_from_double.h
+++ b/src/model/types/cast/cast_from_double.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "cast_to_builtin_type.h"
+#include "icast_to_numeric_type.h"
+namespace model {
+class CastFromDoubleType : public CastToCppType<Double> {};
+class CastFromDoubleTypeToNumeric : public ICastToNumericType {
+public:
+    std::byte* CastToDoubleType(const std::byte* data) override {
+        return this->MakeValue<Double>(*reinterpret_cast<const Double*>(data));
+    }
+    std::byte* CastToIntType(const std::byte* data) override {
+        return this->MakeValue<Int>(static_cast<Int>(*reinterpret_cast<const Double*>(data)));
+    }
+};
+}  // namespace model

--- a/src/model/types/cast/cast_from_int.h
+++ b/src/model/types/cast/cast_from_int.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "cast_to_builtin_type.h"
+namespace model {
+class CastFromIntType : public CastToCppType<Int> {};
+class CastFromIntTypeToNumeric : public ICastToNumericType {
+public:
+    std::byte* CastToDoubleType(const std::byte* data) override {
+        return this->MakeValue<Double>(static_cast<Double>(*reinterpret_cast<const Int*>(data)));
+    }
+    std::byte* CastToIntType(const std::byte* data) override {
+        return this->MakeValue<Int>(static_cast<Int>(*reinterpret_cast<const Int*>(data)));
+    }
+};
+}  // namespace model

--- a/src/model/types/cast/cast_to_builtin_type.h
+++ b/src/model/types/cast/cast_to_builtin_type.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "icast_to_builtin_type.h"
+namespace model {
+template <typename T>
+class CastToCppType : public ICastToCppType {
+public:
+    model::Double GetDouble(std::byte* buf) override {
+        return static_cast<model::Double>(*reinterpret_cast<T*>(buf));
+    }
+    model::Int GetInt(std::byte* buf) override {
+        return static_cast<model::Int>(*reinterpret_cast<T*>(buf));
+    }
+    float GetFloat(std::byte* buf) override {
+        return static_cast<float>(*reinterpret_cast<T*>(buf));
+    }
+};
+}  // namespace model

--- a/src/model/types/cast/icast_to_builtin_type.h
+++ b/src/model/types/cast/icast_to_builtin_type.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "model/types/builtin.h"
+namespace model {
+class ICastToCppType {
+public:
+    virtual model::Double GetDouble(std::byte* buf) = 0;
+    virtual float GetFloat(std::byte* buf) = 0;
+    virtual model::Int GetInt(std::byte* buf) = 0;
+    template <typename return_type>
+    return_type UnsafeCastToCpp(model::TypeId inp_type, std::byte* buf) {
+        switch (inp_type) {
+            case model::TypeId::kDouble: {
+                static_assert(std::is_same<return_type, Double>::value,
+                              "can only convert model::DoubleType to Double");
+                return *reinterpret_cast<Double*>(buf);
+            } break;
+            case model::TypeId::kInt: {
+                static_assert(std::is_same<return_type, Int>::value,
+                              "can only convert model::IntType to Int");
+                return *reinterpret_cast<model::Int*>(buf);
+            }
+            default:
+                static_assert(true, "undefined type conversion");
+                break;
+        }
+    }
+};
+}  // namespace model

--- a/src/model/types/cast/icast_to_numeric_type.h
+++ b/src/model/types/cast/icast_to_numeric_type.h
@@ -1,0 +1,16 @@
+#pragma once
+namespace model {
+class ICastToNumericType {
+public:
+    virtual std::byte* CastToDoubleType(const std::byte* data) = 0;
+    virtual std::byte* CastToIntType(const std::byte* data) = 0;
+
+protected:
+    template <typename T>
+    std::byte* MakeValue(T const literal) const {
+        auto* buf = new std::byte[sizeof(T)];
+        *reinterpret_cast<T*>(buf) = literal;
+        return buf;
+    }
+};
+}  // namespace model

--- a/src/model/types/double_type.h
+++ b/src/model/types/double_type.h
@@ -2,8 +2,10 @@
 
 #include "numeric_type.h"
 
-namespace model {
+//#include "int_type.h"
 
+#include "cast/cast_from_double.h"
+namespace model {
 class DoubleType final : public NumericType<Double> {
 public:
     DoubleType() noexcept : NumericType<Double>(TypeId::kDouble) {}
@@ -37,6 +39,15 @@ public:
             return nullptr;
         }
     }
-};
+    ICastToCppType& CastToBuiltin() override {
+        return this->caster_to_builtin_;
+    }
+    ICastToNumericType& CastToNumeric() override {
+        return this->caster_to_numeric_;
+    }
 
+protected:
+    model::CastFromDoubleType caster_to_builtin_;
+    CastFromDoubleTypeToNumeric caster_to_numeric_;
+};
 }  // namespace model

--- a/src/model/types/int_type.h
+++ b/src/model/types/int_type.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "cast/cast_from_int.h"
+#include "double_type.h"
 #include "numeric_type.h"
-
 namespace model {
-
 class IntType final : public NumericType<Int> {
 public:
     IntType() noexcept : NumericType<Int>(TypeId::kInt) {}
@@ -11,6 +11,16 @@ public:
     [[nodiscard]] std::unique_ptr<Type> CloneType() const override {
         return std::make_unique<IntType>();
     }
+    ICastToCppType& CastToBuiltin() override {
+        return this->caster_to_builtin_;
+    }
+    ICastToNumericType& CastToNumeric() override {
+        return this->caster_to_numeric_;
+    }
+
+protected:
+    model::CastFromIntType caster_to_builtin_;
+    CastFromIntTypeToNumeric caster_to_numeric_;
 };
 
 }  // namespace model


### PR DESCRIPTION

Each inheritor of model::INumericType now can be casted to any other INumericType inheritor and to any builtin type. That will help to improve working experience with custom type system, and allows to implement data storing inside model::NumericType class in future