### PR TITLE
Introduce new CFD class

### DIFF
--- a/src/core/algorithms/cfd/cfd_discovery.h
+++ b/src/core/algorithms/cfd/cfd_discovery.h
@@ -29,7 +29,7 @@ protected:
 
     unsigned columns_number_;
     unsigned tuples_number_;
-    CFDList cfd_list_;
+    ItemsetCFDList cfd_list_;
     std::shared_ptr<CFDRelationData> relation_;
 
 public:
@@ -38,9 +38,10 @@ public:
     explicit CFDDiscovery();
     void LoadDataInternal() final;
     int NrCfds() const;
+    ItemsetCFDList const& GetItemsetCfds() const;
     CFDList GetCfds() const;
     std::string GetRelationString(char delim = ' ') const;
     std::string GetRelationString(const SimpleTIdList& subset, char delim = ' ') const;
-    std::string GetCfdString(CFD const& cfd) const;
+    std::string GetCfdString(ItemsetCFD const& cfd) const;
 };
 }  // namespace algos::cfd

--- a/src/core/algorithms/cfd/model/cfd_relation_data.cpp
+++ b/src/core/algorithms/cfd/model/cfd_relation_data.cpp
@@ -31,7 +31,7 @@ void CFDRelationData::AddNewItemsInFullTable(ItemDictionary& item_dictionary,
             it = ptr->second;
         } else {
             items.emplace_back(string_row[i], i);
-            columns_values_dict[static_cast<int>(i)].push_back(unique_elems_number);
+            columns_values_dict[static_cast<AttributeIndex>(i)].push_back(unique_elems_number);
             item_dictionary[std::make_pair(i, string_row[i])] = unique_elems_number;
             it = unique_elems_number++;
         }
@@ -74,7 +74,7 @@ std::unique_ptr<CFDRelationData> CFDRelationData::CreateFrom(model::IDatasetStre
     }
 
     std::vector<CFDColumnData> column_data;
-    for (int i = 0; static_cast<size_t>(i) < num_columns; ++i) {
+    for (AttributeIndex i = 0; static_cast<size_t>(i) < num_columns; ++i) {
         auto column = Column(schema.get(), parser.GetColumnName(i), i);
         schema->AppendColumn(std::move(column));
         column_data.emplace_back(schema->GetColumn(i), columns_values_dict[i]);
@@ -94,7 +94,7 @@ void CFDRelationData::AddNewItemsInPartialTable(ItemDictionary& item_dictionary,
                                                 std::vector<Transaction>& data_rows,
                                                 int& unique_elems_number, int size) {
     std::vector<int> int_row(size);
-    int j = 0;
+    AttributeIndex j = 0;
     int it;
     for (size_t i = 0; i < string_row.size(); i++) {
         if (!std::binary_search(columns_numbers_list.begin(), columns_numbers_list.end(), i)) {
@@ -150,7 +150,7 @@ std::unique_ptr<CFDRelationData> CFDRelationData::CreateFrom(model::IDatasetStre
     }
 
     std::vector<CFDColumnData> column_data;
-    for (int i = 0; i < num_columns; ++i) {
+    for (AttributeIndex i = 0; i < num_columns; ++i) {
         auto column = Column(schema.get(), file_input.GetColumnName(i), i);
         schema->AppendColumn(std::move(column));
         column_data.emplace_back(schema->GetColumn(i), columns_values_dict[i]);
@@ -262,7 +262,7 @@ std::string CFDRelationData::GetStringFormat(char delim) const {
 std::string CFDRelationData::GetStringFormat(const SimpleTIdList& subset, char delim) const {
     std::string result;
     for (size_t ai = 0; ai < GetNumColumns(); ai++) {
-        const auto& attr = GetAttrName(static_cast<int>(ai));
+        const auto& attr = GetAttrName(static_cast<AttributeIndex>(ai));
         result += attr;
         if (ai < GetNumColumns() - 1) {
             result += delim;
@@ -293,7 +293,7 @@ const std::string& CFDRelationData::GetValue(int i) const {
 std::vector<int> CFDRelationData::GetAttrVector(const Itemset& items) const {
     std::vector<int> attrs;
     attrs.reserve(items.size());
-    for (int i : items) {
+    for (Item i : items) {
         if (i > 0) {
             attrs.push_back(GetAttrIndex(i));
         } else {
@@ -307,7 +307,7 @@ std::vector<int> CFDRelationData::GetAttrVector(const Itemset& items) const {
 std::vector<int> CFDRelationData::GetAttrVectorItems(const Itemset& items) const {
     std::vector<int> attrs;
     attrs.reserve(items.size());
-    for (int i : items) {
+    for (Item i : items) {
         if (i > 0) {
             attrs.push_back(-1 - GetAttrIndex(i));
         } else {

--- a/src/core/algorithms/cfd/model/cfd_relation_data.h
+++ b/src/core/algorithms/cfd/model/cfd_relation_data.h
@@ -19,14 +19,14 @@ namespace algos::cfd {
 class CFDRelationData : public AbstractRelationData<CFDColumnData> {
 private:
     using ItemDictionary = boost::unordered_map<std::pair<int, std::string>, int, PairHash>;
-    using ColumnesValuesDict = std::unordered_map<int, std::vector<int>>;
+    using ColumnesValuesDict = std::unordered_map<AttributeIndex, std::vector<int>>;
     // ItemInfo contains info about one elem in the table.
     struct ItemInfo {
         ItemInfo() = default;
-        ItemInfo(std::string val, int attr)
+        ItemInfo(std::string val, AttributeIndex attr)
             : value(std::move(val)), attribute(attr), frequency(0) {}
         std::string value;
-        int attribute;
+        AttributeIndex attribute;
         unsigned frequency;
     };
 
@@ -57,7 +57,7 @@ public:
     void Sort();
     void ToFront(const SimpleTIdList &);
     void SetRow(int row_index, const Transaction &row);
-    int GetAttrIndex(int item_index) const;
+    AttributeIndex GetAttrIndex(int item_index) const;
     unsigned Frequency(int i) const;
     const std::string &GetValue(int i) const;
     const std::vector<int> &GetDomainOfItem(int) const;

--- a/src/core/algorithms/cfd/model/cfd_types.h
+++ b/src/core/algorithms/cfd/model/cfd_types.h
@@ -10,6 +10,8 @@
 #include <boost/functional/hash.hpp>
 #include <boost/unordered_map.hpp>
 
+#include "raw_cfd.h"
+
 // see algorithms/cfd/LICENSE
 
 namespace algos::cfd {
@@ -30,8 +32,9 @@ using SimpleTIdList = std::vector<Item>;
 using PairHash = boost::hash<std::pair<int, std::string>>;
 
 // Representation of CFD of the form left items -> right item
-using CFD = std::pair<Itemset, int>;
-using CFDList = std::vector<CFD>;
+using ItemsetCFD = std::pair<Itemset, Item>;
+using ItemsetCFDList = std::vector<ItemsetCFD>;
+using CFDList = std::list<RawCFD>;
 
 // Aliases for frequently used types
 using PartitionList = std::vector<std::pair<Itemset, std::vector<unsigned>>>;

--- a/src/core/algorithms/cfd/model/raw_cfd.cpp
+++ b/src/core/algorithms/cfd/model/raw_cfd.cpp
@@ -1,0 +1,35 @@
+#include "raw_cfd.h"
+
+#include <sstream>
+
+namespace algos::cfd {
+
+static std::string RawItemToJSON(RawCFD::RawItem const& raw_item) {
+    std::stringstream ss;
+    ss << "{\"attribute\":" << raw_item.attribute;
+    ss << ",\"value\":";
+    if (raw_item.value.has_value()) {
+        ss << '"' << raw_item.value.value() << '"';
+    } else {
+        ss << "null";
+    }
+    ss << "}";
+    return ss.str();
+}
+
+std::string RawCFD::ToJSON() const {
+    std::stringstream ss;
+    ss << "{\"lhs\":";
+    ss << "[";
+    for (auto it = lhs_.begin(); it != lhs_.end(); ++it) {
+        if (it != lhs_.begin()) {
+            ss << ",";
+        }
+        ss << RawItemToJSON(*it);
+    }
+    ss << "]";
+    ss << ",\"rhs\":" + RawItemToJSON(rhs_) + "}";
+    return ss.str();
+}
+
+}  // namespace algos::cfd

--- a/src/core/algorithms/cfd/model/raw_cfd.h
+++ b/src/core/algorithms/cfd/model/raw_cfd.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace algos::cfd {
+
+using AttributeIndex = int;
+
+class RawCFD {
+public:
+    struct RawItem {
+        AttributeIndex attribute;         /* attribute column index */
+        std::optional<std::string> value; /* pattern value is optional */
+    };
+    using RawItems = std::vector<RawItem>;
+
+private:
+    RawItems lhs_;
+    RawItem rhs_;
+
+public:
+    explicit RawCFD(RawItems lhs, RawItem rhs) : lhs_(std::move(lhs)), rhs_(std::move(rhs)) {}
+
+    std::string ToJSON() const;
+
+    RawItems const& GetLhs() const {
+        return lhs_;
+    }
+    RawItem const& GetRhs() const {
+        return rhs_;
+    }
+};
+
+}  // namespace algos::cfd

--- a/src/core/algorithms/cfd/util/cfd_output_util.cpp
+++ b/src/core/algorithms/cfd/util/cfd_output_util.cpp
@@ -1,0 +1,68 @@
+#include "cfd_output_util.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include "algorithms/cfd/model/cfd_relation_data.h"
+#include "algorithms/cfd/model/cfd_types.h"
+
+// see algorithms/cfd/LICENSE
+
+namespace algos::cfd {
+
+int Output::ItemToAttrIndex(Item item, CFDRelationData const& db) {
+    if (item < 0) {
+        return -1 - item;
+    } else {
+        return db.GetAttrIndex(item);
+    }
+}
+
+std::optional<std::string> Output::ItemToPatternOpt(Item item, CFDRelationData const& db) {
+    if (item < 0) {
+        return std::nullopt;
+    } else if (item == 0) {
+        return "N/A";
+    } else {
+        return db.GetValue(item);
+    }
+}
+
+std::string Output::ItemToPattern(Item item, CFDRelationData const& db) {
+    std::optional<std::string> pattern_opt = ItemToPatternOpt(item, db);
+    return pattern_opt.has_value() ? "=" + pattern_opt.value() : "";
+}
+
+std::string Output::ItemsetToString(const Itemset& items,
+                                    std::shared_ptr<CFDRelationData const> const& db) {
+    std::string answer;
+    answer += '(';
+    std::vector<std::string> parts;
+    for (uint i = 0; i < items.size(); i++) {
+        Item item = items[i];
+        std::string attr_name =
+                (item == 0) ? db->GetAttrName(static_cast<int>(i)) : ItemToAttrName(item, *db);
+        std::string pattern = ItemToPattern(item, *db);
+        parts.emplace_back(attr_name + pattern);
+    }
+    answer += boost::join(parts, ", ");
+    answer += ")";
+    return answer;
+}
+
+std::string Output::CFDListToString(const ItemsetCFDList& cs,
+                                    std::shared_ptr<CFDRelationData const> const& db) {
+    std::string answer;
+    for (const auto& [lhs, rhs] : cs) {
+        answer += CFDToString(lhs, rhs, db);
+    }
+    return answer;
+}
+
+std::string Output::CFDToString(const Itemset& lhs, Item rhs,
+                                std::shared_ptr<CFDRelationData const> const& db) {
+    std::stringstream ss;
+    ss << ItemsetToString(lhs, db) << " => " << ItemToAttrName(rhs, *db) << ItemToPattern(rhs, *db);
+    return ss.str();
+}
+
+}  // namespace algos::cfd

--- a/src/core/algorithms/cfd/util/cfd_output_util.h
+++ b/src/core/algorithms/cfd/util/cfd_output_util.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <iostream>
-#include <ostream>
-
-#include <boost/algorithm/string.hpp>
+#include <memory>
+#include <optional>
+#include <string>
 
 #include "algorithms/cfd/model/cfd_relation_data.h"
 #include "algorithms/cfd/model/cfd_types.h"
@@ -14,50 +13,27 @@ namespace algos::cfd {
 
 class Output {
 public:
+    static int ItemToAttrIndex(Item item, CFDRelationData const& db);
+
+    static std::string ItemToAttrName(Item item, CFDRelationData const& db) {
+        return db.GetAttrName(ItemToAttrIndex(item, db));
+    }
+
+    static std::optional<std::string> ItemToPatternOpt(Item item, CFDRelationData const& db);
+    static std::string ItemToPattern(Item item, CFDRelationData const& db);
+
     static std::string ItemsetToString(const Itemset& items,
-                                       std::shared_ptr<CFDRelationData const> const& db) {
-        std::string answer;
-        answer += '(';
-        std::vector<std::string> parts;
-        for (uint ix = 0; ix < items.size(); ix++) {
-            int item = items[ix];
-            if (item < 0) {
-                parts.push_back(db->GetAttrName(-1 - item));
-            } else if (item == 0) {
-                parts.push_back(db->GetAttrName((int)ix) + "=N/A");
-            } else {
-                parts.push_back(db->GetAttrName(db->GetAttrIndex(item)) + "=" + db->GetValue(item));
-            }
-        }
-        answer += boost::join(parts, ", ");
-        answer += ")";
-        return answer;
-    }
+                                       std::shared_ptr<CFDRelationData const> const& db);
 
-    static std::string CFDListToString(const CFDList& cs,
-                                       std::shared_ptr<CFDRelationData const> const& db) {
-        std::string answer;
-        for (const auto& c : cs) {
-            answer += CFDToString(c.first, c.second, db);
-        }
-        return answer;
-    }
-
-    static std::string CFDToString(const CFD& c, std::shared_ptr<CFDRelationData const> const& db) {
-        return CFDToString(c.first, c.second, db);
-    }
-
-    static std::string CFDToString(const Itemset& lhs, const int rhs,
+    static std::string CFDListToString(const ItemsetCFDList& cs,
+                                       std::shared_ptr<CFDRelationData const> const& db);
+    static std::string CFDToString(const ItemsetCFD& c,
                                    std::shared_ptr<CFDRelationData const> const& db) {
-        std::string answer;
-        answer = ItemsetToString(lhs, db);
-        answer += " => ";
-        if (rhs < 0) {
-            answer += db->GetAttrName(-1 - rhs);
-        } else {
-            answer += (db->GetAttrName(db->GetAttrIndex(rhs)) + "=" + db->GetValue(rhs));
-        }
-        return answer;
+        const auto& [lhs, rhs] = c;
+        return CFDToString(lhs, rhs, db);
     }
+
+    static std::string CFDToString(const Itemset& lhs, Item rhs,
+                                   std::shared_ptr<CFDRelationData const> const& db);
 };
 }  // namespace algos::cfd

--- a/src/tests/test_cfd_algos.cpp
+++ b/src/tests/test_cfd_algos.cpp
@@ -76,7 +76,7 @@ TEST_F(CFDAlgorithmTest, FullTennisDataset) {
     auto algorithm = CreateAlgorithmInstance(8, 0.85, path, "dfs", 3);
     algorithm->Execute();
     std::set<std::string> actual_cfds;
-    for (auto const& cfd : algorithm->GetCfds()) {
+    for (auto const& cfd : algorithm->GetItemsetCfds()) {
         actual_cfds.insert(algorithm->GetCfdString(cfd));
     }
     std::set<std::string> expected_cfds = {"(windy, temp, outlook) => humidity",
@@ -104,7 +104,7 @@ TEST_F(CFDAlgorithmTest, PartialMushroomDataset) {
     auto algorithm = CreateAlgorithmInstance(4, 0.9, path, "dfs", 4, 4, 50);
     algorithm->Execute();
     std::set<std::string> actual_cfds;
-    for (auto const& cfd : algorithm->GetCfds()) {
+    for (auto const& cfd : algorithm->GetItemsetCfds()) {
         actual_cfds.insert(algorithm->GetCfdString(cfd));
     }
     std::set<std::string> expected_cfds = {"(edible=p) => cap-shape=x",


### PR DESCRIPTION
CFD fixes:
* rename algorithm-specific class (`CFD` --> `ItemsetCFD`);
* add new user-friendly class `CFD` with serialization method `ToJSON`.
 
Resolves #245 issue.

Output example:
```
/* for CFD: (edible=p) => cap-shape=x */
{"lhs":[{"attribute":0,"value":"p"}],"rhs":{"attribute":1,"value":"x"}}

/* for CFD: (windy, temp, outlook) => humidity */
{"lhs":[{"attribute":3,"value":null},{"attribute":1,"value":null},{"attribute":0,"value":null}],"rhs":{"attribute":2,"value":null}}
```