### PR TITLE
Fix float division by zero when constructing ranges in AC

### DIFF
--- a/src/core/algorithms/algebraic_constraints/ac_algorithm.cpp
+++ b/src/core/algorithms/algebraic_constraints/ac_algorithm.cpp
@@ -263,25 +263,34 @@ std::vector<std::byte const*> ACAlgorithm::ConstructDisjunctiveRanges(ACPairs co
         ranges = std::vector<std::byte const*>();
         return ranges;
     }
+
     ACPair const* l_border = ac_pairs.front().get();
     ACPair const* r_border = nullptr;
-    double delta = num_type_->Dist(ac_pairs.front()->GetRes(), ac_pairs.back()->GetRes()) *
-                   (weight / (1 - weight));
 
-    for (size_t i = 0; i < ac_pairs.size() - 1; ++i) {
-        if (num_type_->Dist(ac_pairs[i]->GetRes(), ac_pairs[i + 1]->GetRes()) <= delta) {
-            r_border = ac_pairs[i + 1].get();
-        } else {
-            ranges.emplace_back(l_border->GetRes());
-            ranges.emplace_back(ac_pairs[i]->GetRes());
-            l_border = ac_pairs[i + 1].get();
-            r_border = ac_pairs[i + 1].get();
+    if (weight < 1) {
+        double delta = num_type_->Dist(ac_pairs.front()->GetRes(), ac_pairs.back()->GetRes()) *
+                       (weight / (1 - weight));
+
+        for (size_t i = 0; i < ac_pairs.size() - 1; ++i) {
+            if (num_type_->Dist(ac_pairs[i]->GetRes(), ac_pairs[i + 1]->GetRes()) <= delta) {
+                r_border = ac_pairs[i + 1].get();
+            } else {
+                ranges.emplace_back(l_border->GetRes());
+                ranges.emplace_back(ac_pairs[i]->GetRes());
+                l_border = ac_pairs[i + 1].get();
+                r_border = ac_pairs[i + 1].get();
+            }
         }
+    } else {
+        assert(weight == 1);
+        r_border = ac_pairs.back().get();
     }
+
     if (r_border == ac_pairs.back().get()) {
         ranges.emplace_back(l_border->GetRes());
         ranges.emplace_back(r_border->GetRes());
     }
+
     return ranges;
 }
 

--- a/src/core/algorithms/algebraic_constraints/ac_algorithm.h
+++ b/src/core/algorithms/algebraic_constraints/ac_algorithm.h
@@ -74,8 +74,7 @@ private:
                                            size_t lhs_i, size_t rhs_i);
     /* Returns vector with ranges boundaries. Ranges constructed by grouping results of binary
      * operation between values in ac_pairs. */
-    std::vector<std::byte const*> ConstructDisjunctiveRanges(ACPairs const& ac_pairs,
-                                                             double weight) const;
+    std::vector<std::byte const*> ConstructDisjunctiveRanges(ACPairs const& ac_pairs) const;
     /* Greedily combines ranges if there is more than bumps_limit_ */
     void RestrictRangesAmount(std::vector<std::byte const*>& ranges) const;
     void RegisterOptions();
@@ -89,7 +88,7 @@ public:
     }
     size_t CalculateSampleSize(size_t k_bumps) const;
     /* Returns ranges reconstucted with new weight for pair of columns */
-    RangesCollection ReconstructRangesByColumns(size_t lhs_i, size_t rhs_i, double weight) const;
+    RangesCollection ReconstructRangesByColumns(size_t lhs_i, size_t rhs_i, double weight);
     std::vector<RangesCollection> const& GetRangesCollections() const {
         return ranges_;
     }


### PR DESCRIPTION
`weight` equal to 1 leads to the float division by zero when constructing ranges, avoid it by adding a corresponding check. This doesn't change the observable behavior of the code.
Also, use option member `weight_` when reconstructing ranges so that the value validation check is performed for weight for which ranges are reconstructed.