### PR TITLE
Fixed the MixedType::Clone method in the mixed.

### DIFF
--- a/src/core/model/types/mixed_type.h
+++ b/src/core/model/types/mixed_type.h
@@ -75,14 +75,9 @@ public:
         throw std::logic_error("Mixed type does not have a fixed size");
     }
 
-    //It's correct, but not optimal, need to be rewrited later with other virtual
-    //Clone(std::byte const* value, std::byte const* new_value)
-    [[nodiscard]] std::byte* Clone(std::byte const* value) const override {
+    [[nodiscard]]std::byte* Clone(std::byte const* value)const override{
         std::unique_ptr<Type> type = RetrieveType(value);
-        size_t size = GetMixedValueSize(type.get());
-        auto* new_value = new std::byte[size];
-        ValueFromStr(new_value, ValueToString(value), type.get());
-        return new_value;
+        return type->Clone(value);
     }
 
     /* Note: first kTypeIdSize bytes of dest should contain type_id to cast to */


### PR DESCRIPTION
Изменил метод MixedType::Clone, проблема была в том, что прошлый метод преобразовывал значение в строку, потом обратно, что неэффективно. Я переделал, что для каждого типа вызывается свой Clone