### PR TITLE
Add GetDestructor method

### DIFF
--- a/src/core/model/types/date_type.h
+++ b/src/core/model/types/date_type.h
@@ -110,7 +110,7 @@ public:
         return std::abs(d.days());
     }
 
-    static void Destruct(std::byte const* value) {
+    void Destruct(std::byte const* value) override {
         GetValue<Date>(value).~Date();
     }
 

--- a/src/core/model/types/string_type.h
+++ b/src/core/model/types/string_type.h
@@ -86,7 +86,7 @@ public:
         return util::LevenshteinDistance(GetValue<String>(l), GetValue<String>(r));
     }
 
-    static void Destruct(std::byte const* v) {
+    void Destruct(std::byte const* v) override {
         reinterpret_cast<String const*>(v)->~String();
     }
 };

--- a/src/core/model/types/type.h
+++ b/src/core/model/types/type.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <sstream>
 
@@ -12,8 +13,9 @@ private:
     TypeId type_id_;
 
 public:
-    explicit Type(TypeId const type_id) noexcept : type_id_(type_id) {}
+    using Destructor = std::function<void(std::byte*)>;
 
+    explicit Type(TypeId const type_id) noexcept : type_id_(type_id) {}
     virtual ~Type() = default;
 
     /* Operations on the type itself */
@@ -126,6 +128,8 @@ public:
         return !(type_id == +TypeId::kEmpty || type_id == +TypeId::kNull ||
                  type_id == +TypeId::kUndefined || type_id == +TypeId::kMixed);
     }
+
+    virtual void Destruct(std::byte const* data) {}
 };
 
 }  // namespace model


### PR DESCRIPTION
Provides a more convenient way to destruct an object, used in #327, and perhaps it should be used in `TypedColumnData` too.