### PR TITLE
Display table and column names in INDs

### DIFF
--- a/src/core/algorithms/ind/faida/faida.cpp
+++ b/src/core/algorithms/ind/faida/faida.cpp
@@ -30,7 +30,7 @@ void Faida::MakeExecuteOptsAvailable() {
                           config::kThreadNumberOpt.GetName()});
 }
 
-void Faida::LoadDataInternal() {
+void Faida::LoadINDAlgorithmDataInternal() {
     auto start_time = std::chrono::system_clock::now();
 
     data_ = faida::Preprocessor::CreateHashedStores("Faida", input_tables_, sample_size_);

--- a/src/core/algorithms/ind/faida/faida.h
+++ b/src/core/algorithms/ind/faida/faida.h
@@ -30,7 +30,7 @@ private:
     std::unique_ptr<faida::IInclusionTester> inclusion_tester_;
     std::unique_ptr<faida::Preprocessor> data_;
 
-    void LoadDataInternal() final;
+    void LoadINDAlgorithmDataInternal() final;
     void MakeExecuteOptsAvailable() final;
     unsigned long long ExecuteInternal() final;
     void ResetINDAlgorithmState() override;

--- a/src/core/algorithms/ind/ind.cpp
+++ b/src/core/algorithms/ind/ind.cpp
@@ -2,11 +2,49 @@
 
 #include <sstream>
 
+#include "model/table/column.h"
+
 namespace model {
 
-std::string IND::ToString() const {
+std::string IND::ToShortString() const {
+    auto cc_to_short_string = [](ColumnCombination const& cc) -> std::string {
+        std::stringstream ss;
+        auto table_idx = cc.GetTableIndex();
+        auto const& indices = cc.GetColumnIndices();
+        ss << '(' << table_idx << ", [";
+        for (auto it = indices.begin(); it != indices.end(); ++it) {
+            if (it != indices.begin()) {
+                ss << ", ";
+            }
+            ss << *it;
+        }
+        ss << "])";
+        return ss.str();
+    };
+
     std::stringstream ss;
-    ss << GetLhs().ToString() << " -> " << GetRhs().ToString();
+    ss << cc_to_short_string(GetLhs()) << " -> " << cc_to_short_string(GetRhs());
+    return ss.str();
+}
+
+std::string IND::ToLongString() const {
+    auto cc_to_long_string = [this](ColumnCombination const& cc) -> std::string {
+        std::stringstream ss;
+        auto table_idx = cc.GetTableIndex();
+        auto const& indices = cc.GetColumnIndices();
+        ss << '(' << schemas_->at(table_idx).GetName() << ", [";
+        for (auto it = indices.begin(); it != indices.end(); ++it) {
+            if (it != indices.begin()) {
+                ss << ", ";
+            }
+            ss << schemas_->at(table_idx).GetColumn(*it)->GetName();
+        }
+        ss << "])";
+        return ss.str();
+    };
+
+    std::stringstream ss;
+    ss << cc_to_long_string(GetLhs()) << " -> " << cc_to_long_string(GetRhs());
     return ss.str();
 }
 

--- a/src/core/algorithms/ind/ind.h
+++ b/src/core/algorithms/ind/ind.h
@@ -4,6 +4,8 @@
 #include <string>
 
 #include "model/table/column_combination.h"
+#include "model/table/relational_schema.h"
+#include "model/table/vertical.h"
 
 namespace model {
 
@@ -13,10 +15,12 @@ class IND {
 private:
     std::shared_ptr<ColumnCombination> lhs_;
     std::shared_ptr<ColumnCombination> rhs_;
+    std::shared_ptr<std::vector<RelationalSchema>> schemas_;
 
 public:
-    IND(std::shared_ptr<ColumnCombination> lhs, std::shared_ptr<ColumnCombination> rhs)
-        : lhs_(std::move(lhs)), rhs_(std::move(rhs)) {}
+    IND(std::shared_ptr<ColumnCombination> lhs, std::shared_ptr<ColumnCombination> rhs,
+        std::shared_ptr<std::vector<RelationalSchema>> schemas)
+        : lhs_(std::move(lhs)), rhs_(std::move(rhs)), schemas_(std::move(schemas)) {}
 
     ColumnCombination const& GetLhs() const {
         return *lhs_;
@@ -26,7 +30,9 @@ public:
         return *rhs_;
     }
 
-    std::string ToString() const;
+    std::string ToShortString() const;
+
+    std::string ToLongString() const;
 };
 
 }  // namespace model

--- a/src/core/algorithms/ind/ind_algorithm.cpp
+++ b/src/core/algorithms/ind/ind_algorithm.cpp
@@ -11,4 +11,16 @@ INDAlgorithm::INDAlgorithm(std::vector<std::string_view> phase_names)
     MakeOptionsAvailable({config::kTablesOpt.GetName()});
 }
 
+void INDAlgorithm::LoadDataInternal() {
+    schemas_ = std::make_shared<std::vector<RelationalSchema>>();
+    for (auto const& input_table : input_tables_) {
+        auto& schema = schemas_->emplace_back<std::string>(input_table->GetRelationName());
+        for (size_t i{0}; i < input_table->GetNumberOfColumns(); ++i) {
+            schema.AppendColumn(input_table->GetColumnName(i));
+        }
+    }
+
+    LoadINDAlgorithmDataInternal();
+}
+
 }  // namespace algos

--- a/src/core/algorithms/ind/ind_algorithm.h
+++ b/src/core/algorithms/ind/ind_algorithm.h
@@ -6,6 +6,7 @@
 
 #include "algorithms/algorithm.h"
 #include "ind.h"
+#include "model/table/relational_schema.h"
 #include "tabular_data/input_tables_type.h"
 #include "util/primitive_collection.h"
 
@@ -17,6 +18,11 @@ public:
 
 private:
     util::PrimitiveCollection<IND> ind_collection_;
+    std::shared_ptr<std::vector<RelationalSchema>> schemas_;
+
+    void LoadDataInternal() final;
+
+    virtual void LoadINDAlgorithmDataInternal() = 0;
 
     void ResetState() final {
         ind_collection_.Clear();
@@ -34,7 +40,7 @@ protected:
 
     virtual void RegisterIND(std::shared_ptr<model::ColumnCombination> lhs,
                              std::shared_ptr<model::ColumnCombination> rhs) {
-        ind_collection_.Register(std::move(lhs), std::move(rhs));
+        ind_collection_.Register(std::move(lhs), std::move(rhs), schemas_);
     }
 
     virtual void RegisterIND(IND ind) {

--- a/src/core/algorithms/ind/spider/spider.cpp
+++ b/src/core/algorithms/ind/spider/spider.cpp
@@ -44,7 +44,7 @@ void Spider::MakeExecuteOptsAvailable() {
     MakeOptionsAvailable({config::kErrorOpt.GetName()});
 }
 
-void Spider::LoadDataInternal() {
+void Spider::LoadINDAlgorithmDataInternal() {
     auto const create_domains = [&] {
         domains_ = model::ColumnDomain::CreateFrom(input_tables_, mem_limit_mb_, threads_num_);
     };

--- a/src/core/algorithms/ind/spider/spider.h
+++ b/src/core/algorithms/ind/spider/spider.h
@@ -44,7 +44,7 @@ private:
     StageTimings timings_;                     /*< timings info */
 
     void MakeLoadOptsAvailable();
-    void LoadDataInternal() final;
+    void LoadINDAlgorithmDataInternal() final;
     void MakeExecuteOptsAvailable() final;
 
     using INDAlgorithm::RegisterIND;

--- a/src/core/model/table/relational_schema.h
+++ b/src/core/model/table/relational_schema.h
@@ -30,6 +30,12 @@ public:
     std::unique_ptr<Vertical> empty_vertical_;
 
     RelationalSchema(std::string name);
+
+    RelationalSchema(RelationalSchema const& other) = delete;
+    RelationalSchema& operator=(RelationalSchema const& rhs) = delete;
+    RelationalSchema(RelationalSchema&& other) noexcept = default;
+    RelationalSchema& operator=(RelationalSchema&& rhs) noexcept = default;
+
     void Init();
 
     std::string GetName() const {

--- a/src/python_bindings/ind/bind_ind.cpp
+++ b/src/python_bindings/ind/bind_ind.cpp
@@ -16,7 +16,9 @@ void BindInd(py::module_& main_module) {
 
     auto ind_module = main_module.def_submodule("ind");
     py::class_<IND>(ind_module, "IND")
-            .def("__str__", &IND::ToString)
+            .def("__str__", &IND::ToLongString)
+            .def("to_short_string", &IND::ToShortString)
+            .def("to_long_string", &IND::ToLongString)
             .def("get_lhs", &IND::GetLhs)
             .def("get_rhs", &IND::GetRhs);
 

--- a/src/tests/test_faida.cpp
+++ b/src/tests/test_faida.cpp
@@ -19,7 +19,7 @@ void CheckINDsListsEquality(std::list<model::IND> const& actual, INDTestSet cons
 
     for (auto const& dep : actual) {
         if (expected.find(ToINDTest(dep)) == expected.end()) {
-            FAIL() << "generated dep '" << dep.ToString() << "' is not present in expected";
+            FAIL() << "generated dep '" << dep.ToShortString() << "' is not present in expected";
         }
     }
     SUCCEED();


### PR DESCRIPTION
Add methods and bindings for displaying table and
column names instead of indices in IND algorithms' output